### PR TITLE
Send chat notifications also when build becomes fixed or is unstable

### DIFF
--- a/src/main/java/com/flowdock/jenkins/ChatMessage.java
+++ b/src/main/java/com/flowdock/jenkins/ChatMessage.java
@@ -40,6 +40,10 @@ public class ChatMessage extends FlowdockMessage {
         String buildNo = build.getDisplayName().replaceAll("#", "");
         content.append(projectName + configuration).append(" build ").append(buildNo);
         content.append(" ").append(buildResult.getHumanResult());
+        if (build.getResult() == build.getPreviousBuild().getResult()) {        	
+        	content.append(" still");
+        }
+        content.append(".");
 
         String rootUrl = Hudson.getInstance().getRootUrl();
         String buildLink = (rootUrl == null) ? null : rootUrl + build.getUrl();

--- a/src/main/java/com/flowdock/jenkins/FlowdockNotifier.java
+++ b/src/main/java/com/flowdock/jenkins/FlowdockNotifier.java
@@ -129,11 +129,19 @@ public class FlowdockNotifier extends Notifier {
             api.pushTeamInboxMessage(msg);
             listener.getLogger().println("Flowdock: Team Inbox notification sent successfully");
 
-            if(build.getResult() != Result.SUCCESS && chatNotification) {
-                ChatMessage chatMsg = ChatMessage.fromBuild(build, buildResult, listener);
-                chatMsg.setTags(vars.expand(notificationTags));
-                api.pushChatMessage(chatMsg);
-                logger.println("Flowdock: Chat notification sent successfully");
+            if (chatNotification) {
+                switch (buildResult) {
+                case FAILURE:
+                case FIXED:
+                case UNSTABLE:
+                    ChatMessage chatMsg = ChatMessage.fromBuild(build, buildResult, listener);
+                    chatMsg.setTags(vars.expand(notificationTags));
+                    api.pushChatMessage(chatMsg);
+                    logger.println("Flowdock: Chat notification sent successfully");
+                    break;
+				default:
+					break;
+                }
             }
         }
 

--- a/src/main/java/com/flowdock/jenkins/FlowdockNotifier.java
+++ b/src/main/java/com/flowdock/jenkins/FlowdockNotifier.java
@@ -139,8 +139,8 @@ public class FlowdockNotifier extends Notifier {
                     api.pushChatMessage(chatMsg);
                     logger.println("Flowdock: Chat notification sent successfully");
                     break;
-				default:
-					break;
+                default:
+                    break;
                 }
             }
         }

--- a/src/main/resources/com/flowdock/jenkins/FlowdockNotifier/config.jelly
+++ b/src/main/resources/com/flowdock/jenkins/FlowdockNotifier/config.jelly
@@ -16,7 +16,7 @@
          title="Test connection with Chat notification" progress="Sending..."
          method="testConnection" with="flowToken,notificationTags" />
 
-      <f:entry title="Chat notification when build fails" field="chatNotification">
+      <f:entry title="Chat notification when build fails, becomes instable or returns to stable" field="chatNotification">
         <f:checkbox />
       </f:entry>
 


### PR DESCRIPTION
I would assume most people would like to see some notification when build is fixed or unstable. This is how email notifications are usually configured.