### PR TITLE
Enable comma + whitespace separated notification tags

### DIFF
--- a/src/main/java/com/flowdock/jenkins/ChatMessage.java
+++ b/src/main/java/com/flowdock/jenkins/ChatMessage.java
@@ -20,7 +20,7 @@ public class ChatMessage extends FlowdockMessage {
         StringBuffer postData = new StringBuffer();
         postData.append("content=").append(urlEncode(content));
         postData.append("&external_user_name=").append(urlEncode(externalUserName));
-        postData.append("&tags=").append(urlEncode(tags));
+        postData.append("&tags=").append(urlEncode(removeWhitespace(tags)));
         return postData.toString();
     }
 

--- a/src/main/java/com/flowdock/jenkins/FlowdockMessage.java
+++ b/src/main/java/com/flowdock/jenkins/FlowdockMessage.java
@@ -17,6 +17,10 @@ public abstract class FlowdockMessage {
 
     public abstract String asPostData() throws UnsupportedEncodingException;
 
+    protected String removeWhitespace(String data) {
+        return data == null ? null : tags.replaceAll("\\s", "");
+    }
+
     protected String urlEncode(String data) throws UnsupportedEncodingException {
         return data == null ? "" : URLEncoder.encode(data, "UTF-8");
     }

--- a/src/main/java/com/flowdock/jenkins/TeamInboxMessage.java
+++ b/src/main/java/com/flowdock/jenkins/TeamInboxMessage.java
@@ -69,7 +69,7 @@ public class TeamInboxMessage extends FlowdockMessage {
         postData.append("&source=").append(urlEncode(source));
         postData.append("&project=").append(urlEncode(project));
         postData.append("&link=").append(urlEncode(link));
-        postData.append("&tags=").append(urlEncode(tags));
+        postData.append("&tags=").append(urlEncode(removeWhitespace(tags)));
         return postData.toString();
     }
 


### PR DESCRIPTION
Currently notification tags `foo,bar` produces tags `#foo #bar` but `foo, bar` produces only tag `#foo`. This is really confusing as no error is shown.

This pull request fixes the issue by removing all whitespace characters from tags before posting.