### PR TITLE
Project names, formatting, messaging and url cleanup

### DIFF
--- a/src/main/java/com/flowdock/jenkins/ChatMessage.java
+++ b/src/main/java/com/flowdock/jenkins/ChatMessage.java
@@ -3,6 +3,8 @@ package com.flowdock.jenkins;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Hudson;
+import hudson.model.Result;
+
 import java.io.UnsupportedEncodingException;
 
 public class ChatMessage extends FlowdockMessage {
@@ -17,7 +19,7 @@ public class ChatMessage extends FlowdockMessage {
     }
 
     public String asPostData() throws UnsupportedEncodingException {
-        StringBuffer postData = new StringBuffer();
+        StringBuilder postData = new StringBuilder();
         postData.append("content=").append(urlEncode(content));
         postData.append("&external_user_name=").append(urlEncode(externalUserName));
         postData.append("&tags=").append(urlEncode(removeWhitespace(tags)));
@@ -26,24 +28,46 @@ public class ChatMessage extends FlowdockMessage {
 
     public static ChatMessage fromBuild(AbstractBuild build, BuildResult buildResult, BuildListener listener) {
         ChatMessage msg = new ChatMessage();
-        StringBuffer content = new StringBuffer();
+        StringBuilder content = new StringBuilder();
 
         String projectName = "";
         String configuration = "";
         if(build.getProject().getRootProject() != build.getProject()) {
-            projectName = build.getProject().getRootProject().getName();
-            configuration = " on " + build.getProject().getName();
+            projectName = build.getProject().getRootProject().getDisplayName();
+            configuration = " on " + build.getProject().getDisplayName();
         } else {
-            projectName = build.getProject().getName();
+            projectName = build.getProject().getDisplayName();
         }
-
-        String buildNo = build.getDisplayName().replaceAll("#", "");
-        content.append(projectName + configuration).append(" build ").append(buildNo);
-        content.append(" ").append(buildResult.getHumanResult());
 
         String rootUrl = Hudson.getInstance().getRootUrl();
         String buildLink = (rootUrl == null) ? null : rootUrl + build.getUrl();
-        if(buildLink != null) content.append(" \n").append(buildLink);
+        boolean hasLink = buildLink != null;
+        String buildNo = build.getDisplayName().replaceAll("#", "");
+
+        if(build.getResult() == Result.SUCCESS) {
+            content.append(":white_check_mark:");
+        }
+        else if(build.getResult() == Result.UNSTABLE) {
+            content.append(":heavy_exclamation_mark:");
+        }
+        else if(build.getResult() == Result.FAILURE) {
+            content.append(":x:");
+        }
+        else if(build.getResult() == Result.ABORTED) {
+            content.append(":no_entry_sign:");
+        }
+        else if(build.getResult() == Result.NOT_BUILT) {
+            content.append(":o:");
+        }
+        if(hasLink) {
+            content.append("[");
+        }
+        content.append(projectName + configuration).append(" build ").append(buildNo);
+        content.append(" **").append(buildResult.getHumanResult()).append("**");
+        if(hasLink) {
+            content.append("]");
+            content.append("(" + buildLink + ")");
+        }
 
         msg.setContent(content.toString());
         return msg;

--- a/src/main/java/com/flowdock/jenkins/FlowdockNotifier.java
+++ b/src/main/java/com/flowdock/jenkins/FlowdockNotifier.java
@@ -129,7 +129,7 @@ public class FlowdockNotifier extends Notifier {
             api.pushTeamInboxMessage(msg);
             listener.getLogger().println("Flowdock: Team Inbox notification sent successfully");
 
-            if(build.getResult() != Result.SUCCESS && chatNotification) {
+            if((build.getResult() != Result.SUCCESS || buildResult == BuildResult.FIXED) && chatNotification) {
                 ChatMessage chatMsg = ChatMessage.fromBuild(build, buildResult, listener);
                 chatMsg.setTags(vars.expand(notificationTags));
                 api.pushChatMessage(chatMsg);

--- a/src/main/java/com/flowdock/jenkins/TeamInboxMessage.java
+++ b/src/main/java/com/flowdock/jenkins/TeamInboxMessage.java
@@ -61,7 +61,7 @@ public class TeamInboxMessage extends FlowdockMessage {
     }
 
     public String asPostData() throws UnsupportedEncodingException {
-        StringBuffer postData = new StringBuffer();
+        StringBuilder postData = new StringBuilder();
         postData.append("subject=").append(urlEncode(subject));
         postData.append("&content=").append(urlEncode(content));
         postData.append("&from_address=").append(urlEncode(fromAddress));
@@ -79,10 +79,10 @@ public class TeamInboxMessage extends FlowdockMessage {
         String projectName = "";
         String configuration = "";
         if(build.getProject().getRootProject() != build.getProject()) {
-            projectName = build.getProject().getRootProject().getName();
-            configuration = " on " + build.getProject().getName();
+            projectName = build.getProject().getRootProject().getDisplayName();
+            configuration = " on " + build.getProject().getDisplayName();
         } else {
-            projectName = build.getProject().getName();
+            projectName = build.getProject().getDisplayName();
         }
 
         msg.setProject(projectName.replaceAll("[^a-zA-Z0-9\\-_ ]", ""));
@@ -96,12 +96,12 @@ public class TeamInboxMessage extends FlowdockMessage {
         if(build.getResult().isWorseThan(Result.SUCCESS))
             msg.setFromAddress(FLOWDOCK_BUILD_FAIL_EMAIL);
 
-        StringBuffer content = new StringBuffer();
+        StringBuilder content = new StringBuilder();
         content.append("<h3>").append(projectName).append("</h3>");
         content.append("Build: ").append(build.getDisplayName()).append("<br />");
-        content.append("Result: ").append(buildResult.toString()).append("<br />");
+        content.append("Result: <strong>").append(buildResult.toString()).append("</strong><br />");
         if(buildLink != null)
-            content.append("URL: <a href=\"").append(buildLink).append("\">").append(buildLink).append("</a>").append("<br />");
+            content.append("URL: <a href=\"").append(buildLink).append("\">").append(build.getFullDisplayName()).append("</a>").append("<br />");
 
         EnvVars envVars = build.getEnvironment(listener);
         String vcsInfo = versionControlVariableList(envVars);
@@ -161,7 +161,7 @@ public class TeamInboxMessage extends FlowdockMessage {
     }
 
     private static String versionControlVariableList(EnvVars envVars) {
-        StringBuffer envList = new StringBuffer();
+        StringBuilder envList = new StringBuilder();
 
         if(envVars.get("GIT_BRANCH") != null) {
             envList.append("Git branch: ").append(envVars.get("GIT_BRANCH")).append("<br/>");


### PR DESCRIPTION
If your display name and your project names differ you should use display name
If you are linking to build you should use a display name in a build anchor text,
not the anchor itself