### PR TITLE
Add support for token expansion in the API token field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,4 +65,11 @@
               <layout>default</layout>
             </pluginRepository>
   </pluginRepositories>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>token-macro</artifactId>
+      <version>1.12.1</version>
+    </dependency>
+  </dependencies>
 </project>


### PR DESCRIPTION
This is to enable storing the API token as a secret in Jenkins instead of solely as plain text in the job configuration.
