### PR TITLE
Added configurable subject and content for Flowdock messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,12 +66,12 @@
             </pluginRepository>
   </pluginRepositories>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
-      <scope>test</scope>
-    </dependency>
-</dependencies>
+	<dependencies>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.10.19</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -66,12 +66,12 @@
             </pluginRepository>
   </pluginRepositories>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.10.19</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -66,12 +66,12 @@
             </pluginRepository>
   </pluginRepositories>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.10.19</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -65,4 +65,13 @@
               <layout>default</layout>
             </pluginRepository>
   </pluginRepositories>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.10.19</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 </project>

--- a/src/main/java/com/flowdock/jenkins/ChatMessage.java
+++ b/src/main/java/com/flowdock/jenkins/ChatMessage.java
@@ -1,11 +1,11 @@
 package com.flowdock.jenkins;
 
+import java.io.UnsupportedEncodingException;
+
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
-import hudson.model.Hudson;
 import hudson.model.Result;
-
-import java.io.UnsupportedEncodingException;
+import jenkins.model.Jenkins;
 
 public class ChatMessage extends FlowdockMessage {
     protected String externalUserName;
@@ -26,7 +26,7 @@ public class ChatMessage extends FlowdockMessage {
         return postData.toString();
     }
 
-    public static ChatMessage fromBuild(AbstractBuild build, BuildResult buildResult, BuildListener listener) {
+    public static ChatMessage fromBuild(Jenkins jenkins, AbstractBuild build, BuildResult buildResult, BuildListener listener) {
         ChatMessage msg = new ChatMessage();
         StringBuilder content = new StringBuilder();
 
@@ -39,7 +39,7 @@ public class ChatMessage extends FlowdockMessage {
             projectName = build.getProject().getDisplayName();
         }
 
-        String rootUrl = Hudson.getInstance().getRootUrl();
+        String rootUrl = jenkins.getRootUrl();
         String buildLink = (rootUrl == null) ? null : rootUrl + build.getUrl();
         boolean hasLink = buildLink != null;
         String buildNo = build.getDisplayName().replaceAll("#", "");

--- a/src/main/java/com/flowdock/jenkins/FlowdockAPI.java
+++ b/src/main/java/com/flowdock/jenkins/FlowdockAPI.java
@@ -26,7 +26,7 @@ import org.apache.commons.lang.StringUtils;
 import com.flowdock.jenkins.exception.FlowdockException;
 
 public class FlowdockAPI {
-	private static final Logger LOGGER = Logger.getLogger(FlowdockAPI.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(FlowdockAPI.class.getName());
     private String apiUrl;
     private String flowToken;
 
@@ -98,9 +98,9 @@ public class FlowdockAPI {
         }
     }
 
-	protected HttpURLConnection getConnection(URL url) throws IOException {
-		return (HttpURLConnection)url.openConnection(getProxy());
-	}
+    protected HttpURLConnection getConnection(URL url) throws IOException {
+        return (HttpURLConnection)url.openConnection(getProxy());
+    }
 
     /**
      * Returns the Jenkins proxy configuration. {@link Proxy#NO_PROXY} if none configured.

--- a/src/main/java/com/flowdock/jenkins/FlowdockAPI.java
+++ b/src/main/java/com/flowdock/jenkins/FlowdockAPI.java
@@ -58,7 +58,7 @@ public class FlowdockAPI {
         try {
             // create connection
             url = new URL(flowdockUrl);
-            connection = (HttpURLConnection)url.openConnection(getProxy());
+            connection = getConnection(url);
             connection.setRequestMethod("POST");
             connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
             connection.setRequestProperty("Content-Length", String.valueOf(data.getBytes().length));
@@ -97,6 +97,10 @@ public class FlowdockAPI {
             throw new FlowdockException("IOException in connecting to Flowdock: " + ex.getMessage());
         }
     }
+
+	protected HttpURLConnection getConnection(URL url) throws IOException {
+		return (HttpURLConnection)url.openConnection(getProxy());
+	}
 
     /**
      * Returns the Jenkins proxy configuration. {@link Proxy#NO_PROXY} if none configured.

--- a/src/main/java/com/flowdock/jenkins/FlowdockAPI.java
+++ b/src/main/java/com/flowdock/jenkins/FlowdockAPI.java
@@ -26,7 +26,7 @@ import org.apache.commons.lang.StringUtils;
 import com.flowdock.jenkins.exception.FlowdockException;
 
 public class FlowdockAPI {
-    private static final Logger LOGGER = Logger.getLogger(FlowdockAPI.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(FlowdockAPI.class.getName());
     private String apiUrl;
     private String flowToken;
 
@@ -38,7 +38,7 @@ public class FlowdockAPI {
     public void pushTeamInboxMessage(TeamInboxMessage msg) throws FlowdockException {
         try {
             doPost("/messages/team_inbox/", msg.asPostData());
-        } catch (UnsupportedEncodingException ex) {
+        } catch(UnsupportedEncodingException ex) {
             throw new FlowdockException("Cannot encode request data: " + ex.getMessage());
         }
     }
@@ -46,7 +46,7 @@ public class FlowdockAPI {
     public void pushChatMessage(ChatMessage msg) throws FlowdockException {
         try {
             doPost("/messages/chat/", msg.asPostData());
-        } catch (UnsupportedEncodingException ex) {
+        } catch(UnsupportedEncodingException ex) {
             throw new FlowdockException("Cannot encode request data: " + ex.getMessage());
         }
     }
@@ -72,7 +72,7 @@ public class FlowdockAPI {
             wr.flush();
             wr.close();
 
-            if (connection.getResponseCode() != 200) {
+            if(connection.getResponseCode() != 200) {
                 StringBuffer responseContent = new StringBuffer();
                 try {
                     BufferedReader in = new BufferedReader(new InputStreamReader(connection.getErrorStream()));
@@ -81,33 +81,31 @@ public class FlowdockAPI {
                         responseContent.append(responseLine);
                     }
                     in.close();
-                } catch (Exception ex) {
+                } catch(Exception ex) {
                     // nothing we can do about this
                 } finally {
-                    throw new FlowdockException("Flowdock returned an error response with status "
-                            + connection.getResponseCode() + " " + connection.getResponseMessage() + ", "
-                            + responseContent.toString() + "\n\nURL: " + flowdockUrl);
+                    throw new FlowdockException("Flowdock returned an error response with status " +
+                    connection.getResponseCode() + " " + connection.getResponseMessage() + ", " +
+                    responseContent.toString() + "\n\nURL: " + flowdockUrl);
                 }
             }
-        } catch (MalformedURLException ex) {
+        } catch(MalformedURLException ex) {
             throw new FlowdockException("Flowdock API URL is invalid: " + flowdockUrl);
-        } catch (ProtocolException ex) {
+        } catch(ProtocolException ex) {
             throw new FlowdockException("ProtocolException in connecting to Flowdock: " + ex.getMessage());
-        } catch (IOException ex) {
+        } catch(IOException ex) {
             throw new FlowdockException("IOException in connecting to Flowdock: " + ex.getMessage());
         }
     }
 
-    protected HttpURLConnection getConnection(URL url) throws IOException {
-        return (HttpURLConnection) url.openConnection(getProxy());
-    }
+	protected HttpURLConnection getConnection(URL url) throws IOException {
+		return (HttpURLConnection)url.openConnection(getProxy());
+	}
 
     /**
-     * Returns the Jenkins proxy configuration. {@link Proxy#NO_PROXY} if none
-     * configured.
+     * Returns the Jenkins proxy configuration. {@link Proxy#NO_PROXY} if none configured.
      * 
-     * @return the Jenkins proxy configuration. {@link Proxy#NO_PROXY} if none
-     *         configured.
+     * @return the Jenkins proxy configuration. {@link Proxy#NO_PROXY} if none configured.
      */
     private Proxy getProxy() {
         Proxy proxy = null;
@@ -122,17 +120,15 @@ public class FlowdockAPI {
             SocketAddress socketAddress = new InetSocketAddress(proxyConf.name, proxyConf.port);
             proxy = new Proxy(Type.HTTP, socketAddress);
 
-            // Considering only the presence of a username, implying there's a
-            // pwd. Is it right?
+            // Considering only the presence of a username, implying there's a pwd. Is it right?
             final String userName = proxyConf.getUserName();
             if (StringUtils.isNotEmpty(userName)) {
                 final String passwd = proxyConf.getPassword();
 
-                LOGGER.finest("Proxy authentication found: username=" + userName + ", password empty? "
-                        + StringUtils.isEmpty(passwd));
+                LOGGER.finest("Proxy authentication found: username=" + userName
+                        + ", password empty? " + StringUtils.isEmpty(passwd));
 
-                // Will impact the whole server instance. May not be a good idea
-                // :-/.
+                // Will impact the whole server instance. May not be a good idea :-/.
                 Authenticator.setDefault(new Authenticator() {
                     @Override
                     protected PasswordAuthentication getPasswordAuthentication() {

--- a/src/main/java/com/flowdock/jenkins/FlowdockAPI.java
+++ b/src/main/java/com/flowdock/jenkins/FlowdockAPI.java
@@ -26,7 +26,7 @@ import org.apache.commons.lang.StringUtils;
 import com.flowdock.jenkins.exception.FlowdockException;
 
 public class FlowdockAPI {
-	private static final Logger LOGGER = Logger.getLogger(FlowdockAPI.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(FlowdockAPI.class.getName());
     private String apiUrl;
     private String flowToken;
 
@@ -38,7 +38,7 @@ public class FlowdockAPI {
     public void pushTeamInboxMessage(TeamInboxMessage msg) throws FlowdockException {
         try {
             doPost("/messages/team_inbox/", msg.asPostData());
-        } catch(UnsupportedEncodingException ex) {
+        } catch (UnsupportedEncodingException ex) {
             throw new FlowdockException("Cannot encode request data: " + ex.getMessage());
         }
     }
@@ -46,7 +46,7 @@ public class FlowdockAPI {
     public void pushChatMessage(ChatMessage msg) throws FlowdockException {
         try {
             doPost("/messages/chat/", msg.asPostData());
-        } catch(UnsupportedEncodingException ex) {
+        } catch (UnsupportedEncodingException ex) {
             throw new FlowdockException("Cannot encode request data: " + ex.getMessage());
         }
     }
@@ -72,7 +72,7 @@ public class FlowdockAPI {
             wr.flush();
             wr.close();
 
-            if(connection.getResponseCode() != 200) {
+            if (connection.getResponseCode() != 200) {
                 StringBuffer responseContent = new StringBuffer();
                 try {
                     BufferedReader in = new BufferedReader(new InputStreamReader(connection.getErrorStream()));
@@ -81,31 +81,33 @@ public class FlowdockAPI {
                         responseContent.append(responseLine);
                     }
                     in.close();
-                } catch(Exception ex) {
+                } catch (Exception ex) {
                     // nothing we can do about this
                 } finally {
-                    throw new FlowdockException("Flowdock returned an error response with status " +
-                    connection.getResponseCode() + " " + connection.getResponseMessage() + ", " +
-                    responseContent.toString() + "\n\nURL: " + flowdockUrl);
+                    throw new FlowdockException("Flowdock returned an error response with status "
+                            + connection.getResponseCode() + " " + connection.getResponseMessage() + ", "
+                            + responseContent.toString() + "\n\nURL: " + flowdockUrl);
                 }
             }
-        } catch(MalformedURLException ex) {
+        } catch (MalformedURLException ex) {
             throw new FlowdockException("Flowdock API URL is invalid: " + flowdockUrl);
-        } catch(ProtocolException ex) {
+        } catch (ProtocolException ex) {
             throw new FlowdockException("ProtocolException in connecting to Flowdock: " + ex.getMessage());
-        } catch(IOException ex) {
+        } catch (IOException ex) {
             throw new FlowdockException("IOException in connecting to Flowdock: " + ex.getMessage());
         }
     }
 
-	protected HttpURLConnection getConnection(URL url) throws IOException {
-		return (HttpURLConnection)url.openConnection(getProxy());
-	}
+    protected HttpURLConnection getConnection(URL url) throws IOException {
+        return (HttpURLConnection) url.openConnection(getProxy());
+    }
 
     /**
-     * Returns the Jenkins proxy configuration. {@link Proxy#NO_PROXY} if none configured.
+     * Returns the Jenkins proxy configuration. {@link Proxy#NO_PROXY} if none
+     * configured.
      * 
-     * @return the Jenkins proxy configuration. {@link Proxy#NO_PROXY} if none configured.
+     * @return the Jenkins proxy configuration. {@link Proxy#NO_PROXY} if none
+     *         configured.
      */
     private Proxy getProxy() {
         Proxy proxy = null;
@@ -120,15 +122,17 @@ public class FlowdockAPI {
             SocketAddress socketAddress = new InetSocketAddress(proxyConf.name, proxyConf.port);
             proxy = new Proxy(Type.HTTP, socketAddress);
 
-            // Considering only the presence of a username, implying there's a pwd. Is it right?
+            // Considering only the presence of a username, implying there's a
+            // pwd. Is it right?
             final String userName = proxyConf.getUserName();
             if (StringUtils.isNotEmpty(userName)) {
                 final String passwd = proxyConf.getPassword();
 
-                LOGGER.finest("Proxy authentication found: username=" + userName
-                        + ", password empty? " + StringUtils.isEmpty(passwd));
+                LOGGER.finest("Proxy authentication found: username=" + userName + ", password empty? "
+                        + StringUtils.isEmpty(passwd));
 
-                // Will impact the whole server instance. May not be a good idea :-/.
+                // Will impact the whole server instance. May not be a good idea
+                // :-/.
                 Authenticator.setDefault(new Authenticator() {
                     @Override
                     protected PasswordAuthentication getPasswordAuthentication() {

--- a/src/main/java/com/flowdock/jenkins/FlowdockNotifier.java
+++ b/src/main/java/com/flowdock/jenkins/FlowdockNotifier.java
@@ -34,317 +34,318 @@ import net.sf.json.JSONObject;
 
 public class FlowdockNotifier extends Notifier {
 
-	private final String flowToken;
+    private final String flowToken;
 
-	private String notificationTags;
-	private boolean chatNotification;
+    private String notificationTags;
+    private boolean chatNotification;
 
-	private final Map<BuildResult, Boolean> notifyMap;
+    private final Map<BuildResult, Boolean> notifyMap;
 
-	private String subject;
-	private String content;
+    private String subject;
+    private String content;
 
-	@Deprecated
-	@Restricted(NoExternalUse.class)
-	public FlowdockNotifier(String flowToken, String notificationTags, String chatNotification, String notifySuccess,
-			String notifyFailure, String notifyFixed, String notifyUnstable, String notifyAborted,
-			String notifyNotBuilt) {
-		// Call the new constructor and get all the defaults in place
-		this(flowToken);
+    @Deprecated
+    @Restricted(NoExternalUse.class)
+    public FlowdockNotifier(String flowToken, String notificationTags, String chatNotification, String notifySuccess,
+            String notifyFailure, String notifyFixed, String notifyUnstable, String notifyAborted,
+            String notifyNotBuilt) {
+        // Call the new constructor and get all the defaults in place
+        this(flowToken);
 
-		this.notificationTags = notificationTags;
+        this.notificationTags = notificationTags;
 
-		// Deprecated API is treating the notification flags as strings, not
-		// boolean so we need
-		// this to preserve backwards compatibility
-		notifyMap.put(BuildResult.SUCCESS, notifySuccess != null && notifySuccess.equals("true"));
-		notifyMap.put(BuildResult.FAILURE, notifyFailure != null && notifyFailure.equals("true"));
-		notifyMap.put(BuildResult.FIXED, notifyFixed != null && notifyFixed.equals("true"));
-		notifyMap.put(BuildResult.UNSTABLE, notifyUnstable != null && notifyUnstable.equals("true"));
-		notifyMap.put(BuildResult.ABORTED, notifyAborted != null && notifyAborted.equals("true"));
-		notifyMap.put(BuildResult.NOT_BUILT, notifyNotBuilt != null && notifyNotBuilt.equals("true"));
-	}
+        // Deprecated API is treating the notification flags as strings, not
+        // boolean so we need
+        // this to preserve backwards compatibility
+        notifyMap.put(BuildResult.SUCCESS, notifySuccess != null && notifySuccess.equals("true"));
+        notifyMap.put(BuildResult.FAILURE, notifyFailure != null && notifyFailure.equals("true"));
+        notifyMap.put(BuildResult.FIXED, notifyFixed != null && notifyFixed.equals("true"));
+        notifyMap.put(BuildResult.UNSTABLE, notifyUnstable != null && notifyUnstable.equals("true"));
+        notifyMap.put(BuildResult.ABORTED, notifyAborted != null && notifyAborted.equals("true"));
+        notifyMap.put(BuildResult.NOT_BUILT, notifyNotBuilt != null && notifyNotBuilt.equals("true"));
+    }
 
-	// Fields in config.jelly must match the parameter names in the
-	// "DataBoundConstructor"
-	@DataBoundConstructor
-	public FlowdockNotifier(String flowToken) {
-		this.flowToken = flowToken;
+    // Fields in config.jelly must match the parameter names in the
+    // "DataBoundConstructor"
+    @DataBoundConstructor
+    public FlowdockNotifier(String flowToken) {
+        this.flowToken = flowToken;
 
-		this.chatNotification = true;
+        this.chatNotification = true;
 
-		// set notification map with defaults of true
-		this.notifyMap = new HashMap<BuildResult, Boolean>();
+        // set notification map with defaults of true
+        this.notifyMap = new HashMap<BuildResult, Boolean>();
 
-		// Default value for notifications is always true since we'd rather over-notify
-		// than under
-		for (BuildResult result : BuildResult.values()) {
-			notifyMap.put(result, true);
-		}
-	}
+        // Default value for notifications is always true since we'd rather
+        // over-notify
+        // than under
+        for (BuildResult result : BuildResult.values()) {
+            notifyMap.put(result, true);
+        }
+    }
 
-	public String getFlowToken() {
-		return flowToken;
-	}
+    public String getFlowToken() {
+        return flowToken;
+    }
 
-	public String getNotificationTags() {
-		return notificationTags;
-	}
+    public String getNotificationTags() {
+        return notificationTags;
+    }
 
-	public boolean getChatNotification() {
-		return chatNotification;
-	}
+    public boolean getChatNotification() {
+        return chatNotification;
+    }
 
-	/**
-	 * Returns true if notifications should be performed on success.
-	 * Default value is true.
-	 * 
-	 * @return True if notifications should be performed on success.
-	 */
-	public boolean getNotifySuccess() {
-		return notifyMap.get(BuildResult.SUCCESS);
-	}
+    /**
+     * Returns true if notifications should be performed on success. Default
+     * value is true.
+     * 
+     * @return True if notifications should be performed on success.
+     */
+    public boolean getNotifySuccess() {
+        return notifyMap.get(BuildResult.SUCCESS);
+    }
 
-	/**
-	 * Returns true if notifications should be performed on failure.
-	 * Default value is true.
-	 * 
-	 * @return True if notifications should be performed on failure.
-	 */
-	public boolean getNotifyFailure() {
-		return notifyMap.get(BuildResult.FAILURE);
-	}
+    /**
+     * Returns true if notifications should be performed on failure. Default
+     * value is true.
+     * 
+     * @return True if notifications should be performed on failure.
+     */
+    public boolean getNotifyFailure() {
+        return notifyMap.get(BuildResult.FAILURE);
+    }
 
-	/**
-	 * Returns true if notifications should be performed on fixed builds.
-	 * Default value is true.
-	 * 
-	 * @return True if notifications should be performed on fixed builds.
-	 */
-	public boolean getNotifyFixed() {
-		return notifyMap.get(BuildResult.FIXED);
-	}
+    /**
+     * Returns true if notifications should be performed on fixed builds.
+     * Default value is true.
+     * 
+     * @return True if notifications should be performed on fixed builds.
+     */
+    public boolean getNotifyFixed() {
+        return notifyMap.get(BuildResult.FIXED);
+    }
 
-	/**
-	 * Returns true if notifications should be performed on unstable builds.
-	 * Default value is true.
-	 * 
-	 * @return True if notifications should be performed on unstable builds.
-	 */
-	public boolean getNotifyUnstable() {
-		return notifyMap.get(BuildResult.UNSTABLE);
-	}
+    /**
+     * Returns true if notifications should be performed on unstable builds.
+     * Default value is true.
+     * 
+     * @return True if notifications should be performed on unstable builds.
+     */
+    public boolean getNotifyUnstable() {
+        return notifyMap.get(BuildResult.UNSTABLE);
+    }
 
-	/**
-	 * Returns true if notifications should be performed on aborted builds.
-	 * Default value is true.
-	 * 
-	 * @return True if notifications should be performed on aborted builds.
-	 */
-	public boolean getNotifyAborted() {
-		return notifyMap.get(BuildResult.ABORTED);
-	}
+    /**
+     * Returns true if notifications should be performed on aborted builds.
+     * Default value is true.
+     * 
+     * @return True if notifications should be performed on aborted builds.
+     */
+    public boolean getNotifyAborted() {
+        return notifyMap.get(BuildResult.ABORTED);
+    }
 
-	/**
-	 * Returns true if notifications should be performed on not built.
-	 * Default value is true.
-	 * 
-	 * @return True if notifications should be performed on not built.
-	 */
-	public boolean getNotifyNotBuilt() {
-		return notifyMap.get(BuildResult.NOT_BUILT);
-	}
+    /**
+     * Returns true if notifications should be performed on not built. Default
+     * value is true.
+     * 
+     * @return True if notifications should be performed on not built.
+     */
+    public boolean getNotifyNotBuilt() {
+        return notifyMap.get(BuildResult.NOT_BUILT);
+    }
 
-	public BuildStepMonitor getRequiredMonitorService() {
-		return BuildStepMonitor.NONE;
-	}
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
+    }
 
-	@Override
-	public boolean needsToRunAfterFinalized() {
-		return true;
-	}
+    @Override
+    public boolean needsToRunAfterFinalized() {
+        return true;
+    }
 
-	@Override
-	public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
-		BuildResult buildResult = BuildResult.fromBuild(build);
-		if (shouldNotify(buildResult)) {
-			notifyFlowdock(build, buildResult, listener);
-		} else {
-			listener.getLogger()
-					.println("No Flowdock notification configured for build status: " + buildResult.toString());
-		}
-		return true;
-	}
+    @Override
+    public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
+        BuildResult buildResult = BuildResult.fromBuild(build);
+        if (shouldNotify(buildResult)) {
+            notifyFlowdock(build, buildResult, listener);
+        } else {
+            listener.getLogger()
+                    .println("No Flowdock notification configured for build status: " + buildResult.toString());
+        }
+        return true;
+    }
 
-	public boolean shouldNotify(BuildResult buildResult) {
-		return notifyMap.get(buildResult);
-	}
+    public boolean shouldNotify(BuildResult buildResult) {
+        return notifyMap.get(buildResult);
+    }
 
-	protected void notifyFlowdock(AbstractBuild build, BuildResult buildResult, BuildListener listener) {
-		PrintStream logger = listener.getLogger();
-		try {
-			FlowdockAPI api = getFlowdockAPI();
-			TeamInboxMessage msg = teamInboxMessageFromBuild(build, buildResult, listener);
+    protected void notifyFlowdock(AbstractBuild build, BuildResult buildResult, BuildListener listener) {
+        PrintStream logger = listener.getLogger();
+        try {
+            FlowdockAPI api = getFlowdockAPI();
+            TeamInboxMessage msg = teamInboxMessageFromBuild(build, buildResult, listener);
 
-			EnvVars vars = build.getEnvironment(listener);
+            EnvVars vars = build.getEnvironment(listener);
 
-			// Check for overrides for both content and subject
-			if (StringUtils.isNotBlank(content)) {
-				msg.setContent(vars.expand(content));
-			}
+            // Check for overrides for both content and subject
+            if (StringUtils.isNotBlank(content)) {
+                msg.setContent(vars.expand(content));
+            }
 
-			if (StringUtils.isNotBlank(subject)) {
-				msg.setSubject(vars.expand(subject));
-			}
+            if (StringUtils.isNotBlank(subject)) {
+                msg.setSubject(vars.expand(subject));
+            }
 
-			msg.setTags(vars.expand(notificationTags));
-			api.pushTeamInboxMessage(msg);
-			listener.getLogger().println("Flowdock: Team Inbox notification sent successfully");
+            msg.setTags(vars.expand(notificationTags));
+            api.pushTeamInboxMessage(msg);
+            listener.getLogger().println("Flowdock: Team Inbox notification sent successfully");
 
-			if ((build.getResult() != Result.SUCCESS || buildResult == BuildResult.FIXED) && chatNotification) {
-				ChatMessage chatMsg = chatMessageFromBuild(build, buildResult, listener);
+            if ((build.getResult() != Result.SUCCESS || buildResult == BuildResult.FIXED) && chatNotification) {
+                ChatMessage chatMsg = chatMessageFromBuild(build, buildResult, listener);
 
-				if (StringUtils.isNotBlank(content)) {
-					chatMsg.setContent(vars.expand(content));
-				}
+                if (StringUtils.isNotBlank(content)) {
+                    chatMsg.setContent(vars.expand(content));
+                }
 
-				chatMsg.setTags(vars.expand(notificationTags));
-				api.pushChatMessage(chatMsg);
-				logger.println("Flowdock: Chat notification sent successfully");
-			}
-		}
+                chatMsg.setTags(vars.expand(notificationTags));
+                api.pushChatMessage(chatMsg);
+                logger.println("Flowdock: Chat notification sent successfully");
+            }
+        }
 
-		catch (IOException ex) {
-			logger.println("Flowdock: failed to get variables from build");
-			logger.println("Flowdock: " + ex.getMessage());
-		}
+        catch (IOException ex) {
+            logger.println("Flowdock: failed to get variables from build");
+            logger.println("Flowdock: " + ex.getMessage());
+        }
 
-		catch (InterruptedException ex) {
-			logger.println("Flowdock: failed to get variables from build");
-			logger.println("Flowdock: " + ex.getMessage());
-		}
+        catch (InterruptedException ex) {
+            logger.println("Flowdock: failed to get variables from build");
+            logger.println("Flowdock: " + ex.getMessage());
+        }
 
-		catch (FlowdockException ex) {
-			logger.println("Flowdock: failed to send notification");
-			logger.println("Flowdock: " + ex.getMessage());
-		}
+        catch (FlowdockException ex) {
+            logger.println("Flowdock: failed to send notification");
+            logger.println("Flowdock: " + ex.getMessage());
+        }
 
-	}
+    }
 
-	protected FlowdockAPI getFlowdockAPI() {
-		return new FlowdockAPI(getDescriptor().apiUrl(), flowToken);
-	}
+    protected FlowdockAPI getFlowdockAPI() {
+        return new FlowdockAPI(getDescriptor().apiUrl(), flowToken);
+    }
 
-	protected ChatMessage chatMessageFromBuild(AbstractBuild build, BuildResult buildResult, BuildListener listener) {
-		return ChatMessage.fromBuild(Jenkins.getInstance(), build, buildResult, listener);
-	}
+    protected ChatMessage chatMessageFromBuild(AbstractBuild build, BuildResult buildResult, BuildListener listener) {
+        return ChatMessage.fromBuild(Jenkins.getInstance(), build, buildResult, listener);
+    }
 
-	protected TeamInboxMessage teamInboxMessageFromBuild(AbstractBuild build, BuildResult buildResult,
-			BuildListener listener) throws IOException, InterruptedException {
-		return TeamInboxMessage.fromBuild(Jenkins.getInstance(), build, buildResult, listener);
-	}
+    protected TeamInboxMessage teamInboxMessageFromBuild(AbstractBuild build, BuildResult buildResult,
+            BuildListener listener) throws IOException, InterruptedException {
+        return TeamInboxMessage.fromBuild(Jenkins.getInstance(), build, buildResult, listener);
+    }
 
-	@Override
-	public DescriptorImpl getDescriptor() {
-		return (DescriptorImpl) super.getDescriptor();
-	}
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return (DescriptorImpl) super.getDescriptor();
+    }
 
-	@Extension
-	public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+    @Extension
+    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
-		private String apiUrl = "https://api.flowdock.com";
+        private String apiUrl = "https://api.flowdock.com";
 
-		public boolean isApplicable(Class<? extends AbstractProject> aClass) {
-			return true;
-		}
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+            return true;
+        }
 
-		public String getDisplayName() {
-			return "Flowdock notification";
-		}
+        public String getDisplayName() {
+            return "Flowdock notification";
+        }
 
-		public FormValidation doTestConnection(@QueryParameter("flowToken") final String flowToken,
-				@QueryParameter("notificationTags") final String notificationTags) {
-			try {
-				FlowdockAPI api = new FlowdockAPI(apiUrl(), flowToken);
-				ChatMessage testMsg = new ChatMessage();
-				testMsg.setTags(notificationTags);
-				testMsg.setContent("Your plugin is ready!");
-				api.pushChatMessage(testMsg);
-				return FormValidation.ok("Success! Flowdock plugin can send notifications to your flow.");
-			} catch (FlowdockException ex) {
-				return FormValidation.error(ex.getMessage());
-			}
-		}
+        public FormValidation doTestConnection(@QueryParameter("flowToken") final String flowToken,
+                @QueryParameter("notificationTags") final String notificationTags) {
+            try {
+                FlowdockAPI api = new FlowdockAPI(apiUrl(), flowToken);
+                ChatMessage testMsg = new ChatMessage();
+                testMsg.setTags(notificationTags);
+                testMsg.setContent("Your plugin is ready!");
+                api.pushChatMessage(testMsg);
+                return FormValidation.ok("Success! Flowdock plugin can send notifications to your flow.");
+            } catch (FlowdockException ex) {
+                return FormValidation.error(ex.getMessage());
+            }
+        }
 
-		@Override
-		public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
-			apiUrl = formData.getString("apiUrl");
-			save();
-			return super.configure(req, formData);
-		}
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+            apiUrl = formData.getString("apiUrl");
+            save();
+            return super.configure(req, formData);
+        }
 
-		public String apiUrl() {
-			return apiUrl;
-		}
-	}
+        public String apiUrl() {
+            return apiUrl;
+        }
+    }
 
-	@CheckForNull
-	public String getSubject() {
-		return subject;
-	}
+    @CheckForNull
+    public String getSubject() {
+        return subject;
+    }
 
-	@CheckForNull
-	public String getContent() {
-		return content;
-	}
+    @CheckForNull
+    public String getContent() {
+        return content;
+    }
 
-	@DataBoundSetter
-	public void setSubject(String subject) {
-		this.subject = StringUtils.isNotBlank(subject) ? subject : null;
-	}
+    @DataBoundSetter
+    public void setSubject(String subject) {
+        this.subject = StringUtils.isNotBlank(subject) ? subject : null;
+    }
 
-	@DataBoundSetter
-	public void setContent(String content) {
-		this.content = StringUtils.isNotBlank(content) ? content : null;
-	}
+    @DataBoundSetter
+    public void setContent(String content) {
+        this.content = StringUtils.isNotBlank(content) ? content : null;
+    }
 
-	@DataBoundSetter
-	public void setNotifySuccess(boolean notifySuccess) {
-		notifyMap.put(BuildResult.SUCCESS, notifySuccess);
-	}
+    @DataBoundSetter
+    public void setNotifySuccess(boolean notifySuccess) {
+        notifyMap.put(BuildResult.SUCCESS, notifySuccess);
+    }
 
-	@DataBoundSetter
-	public void setNotifyFailure(boolean notifyFailure) {
-		notifyMap.put(BuildResult.FAILURE, notifyFailure);
-	}
+    @DataBoundSetter
+    public void setNotifyFailure(boolean notifyFailure) {
+        notifyMap.put(BuildResult.FAILURE, notifyFailure);
+    }
 
-	@DataBoundSetter
-	public void setNotifyFixed(boolean notifyFixed) {
-		notifyMap.put(BuildResult.FIXED, notifyFixed);
-	}
+    @DataBoundSetter
+    public void setNotifyFixed(boolean notifyFixed) {
+        notifyMap.put(BuildResult.FIXED, notifyFixed);
+    }
 
-	@DataBoundSetter
-	public void setNotifyUnstable(boolean notifyUnstable) {
-		notifyMap.put(BuildResult.UNSTABLE, notifyUnstable);
-	}
+    @DataBoundSetter
+    public void setNotifyUnstable(boolean notifyUnstable) {
+        notifyMap.put(BuildResult.UNSTABLE, notifyUnstable);
+    }
 
-	@DataBoundSetter
-	public void setNotifyAborted(boolean notifyAborted) {
-		notifyMap.put(BuildResult.ABORTED, notifyAborted);
-	}
+    @DataBoundSetter
+    public void setNotifyAborted(boolean notifyAborted) {
+        notifyMap.put(BuildResult.ABORTED, notifyAborted);
+    }
 
-	@DataBoundSetter
-	public void setNotifyNotBuilt(boolean notifyNotBuilt) {
-		notifyMap.put(BuildResult.NOT_BUILT, notifyNotBuilt);
-	}
+    @DataBoundSetter
+    public void setNotifyNotBuilt(boolean notifyNotBuilt) {
+        notifyMap.put(BuildResult.NOT_BUILT, notifyNotBuilt);
+    }
 
-	@DataBoundSetter
-	public void setNotificationTags(String notificationTags) {
-		this.notificationTags = notificationTags;
-	}
+    @DataBoundSetter
+    public void setNotificationTags(String notificationTags) {
+        this.notificationTags = notificationTags;
+    }
 
-	@DataBoundSetter
-	public void setChatNotification(boolean chatNotification) {
-		this.chatNotification = chatNotification;
-	}
+    @DataBoundSetter
+    public void setChatNotification(boolean chatNotification) {
+        this.chatNotification = chatNotification;
+    }
 }

--- a/src/main/java/com/flowdock/jenkins/FlowdockNotifier.java
+++ b/src/main/java/com/flowdock/jenkins/FlowdockNotifier.java
@@ -5,6 +5,11 @@ import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.CheckForNull;
+
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -28,210 +33,264 @@ import net.sf.json.JSONObject;
 
 public class FlowdockNotifier extends Notifier {
 
-    private final String flowToken;
+	private final String flowToken;
 
-    private String notificationTags;
-    private boolean chatNotification;
+	private String notificationTags;
+	private boolean chatNotification;
 
-    private final Map<BuildResult, Boolean> notifyMap;
+	private final Map<BuildResult, Boolean> notifyMap;
 
-    private String subject;
-    private String content;
-    
-    // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
-    @DataBoundConstructor
-    public FlowdockNotifier(String flowToken) {
-        this.flowToken = flowToken;
+	private String subject;
+	private String content;
 
-        this.chatNotification = true;
+	@Deprecated
+	@Restricted(NoExternalUse.class)
+	public FlowdockNotifier(String flowToken, String notificationTags, String chatNotification, String notifySuccess,
+			String notifyFailure, String notifyFixed, String notifyUnstable, String notifyAborted,
+			String notifyNotBuilt) {
+		// Call the new constructor and get all the defaults in place
+		this(flowToken);
 
-        // set notification map with defaults of true
-        this.notifyMap = new HashMap<BuildResult, Boolean>();
-        this.notifyMap.put(BuildResult.SUCCESS, true);
-        this.notifyMap.put(BuildResult.FAILURE, true);
-        this.notifyMap.put(BuildResult.FIXED, true);
-        this.notifyMap.put(BuildResult.UNSTABLE, true);
-        this.notifyMap.put(BuildResult.ABORTED, true);
-        this.notifyMap.put(BuildResult.NOT_BUILT, true);
-    }
+		this.notificationTags = notificationTags;
 
-    public String getFlowToken() {
-        return flowToken;
-    }
+		// Deprecated API is treating the notification flags as strings, not
+		// boolean so we need
+		// this to preserve backwards compatibility
+		notifyMap.put(BuildResult.SUCCESS, notifySuccess != null && notifySuccess.equals("true"));
+		notifyMap.put(BuildResult.FAILURE, notifyFailure != null && notifyFailure.equals("true"));
+		notifyMap.put(BuildResult.FIXED, notifyFixed != null && notifyFixed.equals("true"));
+		notifyMap.put(BuildResult.UNSTABLE, notifyUnstable != null && notifyUnstable.equals("true"));
+		notifyMap.put(BuildResult.ABORTED, notifyAborted != null && notifyAborted.equals("true"));
+		notifyMap.put(BuildResult.NOT_BUILT, notifyNotBuilt != null && notifyNotBuilt.equals("true"));
+	}
 
-    public String getNotificationTags() {
-        return notificationTags;
-    }
+	// Fields in config.jelly must match the parameter names in the
+	// "DataBoundConstructor"
+	@DataBoundConstructor
+	public FlowdockNotifier(String flowToken) {
+		this.flowToken = flowToken;
 
-    public boolean getChatNotification() {
-        return chatNotification;
-    }
+		this.chatNotification = true;
 
-    public boolean getNotifySuccess() {
-        return notifyMap.get(BuildResult.SUCCESS);
-    }
-    public boolean getNotifyFailure() {
-        return notifyMap.get(BuildResult.FAILURE);
-    }
-    public boolean getNotifyFixed() {
-        return notifyMap.get(BuildResult.FIXED);
-    }
-    public boolean getNotifyUnstable() {
-        return notifyMap.get(BuildResult.UNSTABLE);
-    }
-    public boolean getNotifyAborted() {
-        return notifyMap.get(BuildResult.ABORTED);
-    }
-    public boolean getNotifyNotBuilt() {
-        return notifyMap.get(BuildResult.NOT_BUILT);
-    }
+		// set notification map with defaults of true
+		this.notifyMap = new HashMap<BuildResult, Boolean>();
 
-    public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.NONE;
-    }
+		// Default value for notifications is always true
+		for (BuildResult result : BuildResult.values()) {
+			notifyMap.put(result, true);
+		}
+	}
 
-    @Override
-    public boolean needsToRunAfterFinalized() {
-        return true;
-    }
+	public String getFlowToken() {
+		return flowToken;
+	}
 
-    @Override
-    public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
-        BuildResult buildResult = BuildResult.fromBuild(build);
-        if(shouldNotify(buildResult)) {
-            notifyFlowdock(build, buildResult, listener);
-        } else {
-            listener.getLogger().println("No Flowdock notification configured for build status: " + buildResult.toString());
-        }
-        return true;
-    }
+	public String getNotificationTags() {
+		return notificationTags;
+	}
 
-    public boolean shouldNotify(BuildResult buildResult) {
-        return notifyMap.get(buildResult);
-    }
+	public boolean getChatNotification() {
+		return chatNotification;
+	}
 
-    /**
-     * Returns true if the value is non-null and at least one character long.
-     * 
-     * @param value A value.
-     * @return True if the value is non-null and has at least one non-blank character.
-     */
-    private boolean isValueSet(String value) {
-    	return value != null && value.trim().length() > 0;
-    }
-    
-    protected void notifyFlowdock(AbstractBuild build, BuildResult buildResult, BuildListener listener) {
-        PrintStream logger = listener.getLogger();
-        try {
-            FlowdockAPI api = new FlowdockAPI(getDescriptor().apiUrl(), flowToken);
-            TeamInboxMessage msg = TeamInboxMessage.fromBuild(build, buildResult, listener);
-            
-            EnvVars vars = build.getEnvironment(listener);
-            
-            // Check for overrides for both content and subject
-            if (isValueSet(content)) {
-            	msg.setContent(vars.expand(content));
-            }
-            
-            if (isValueSet(subject)) {
-            	msg.setSubject(vars.expand(subject));
-            }
-            
-            msg.setTags(vars.expand(notificationTags));
-            api.pushTeamInboxMessage(msg);
-            listener.getLogger().println("Flowdock: Team Inbox notification sent successfully");
+	/**
+	 * Returns true if notifications should be performed on success.
+	 * Default value is true.
+	 * 
+	 * @return True if notifications should be performed on success.
+	 */
+	public boolean getNotifySuccess() {
+		return notifyMap.get(BuildResult.SUCCESS);
+	}
 
-            if((build.getResult() != Result.SUCCESS || buildResult == BuildResult.FIXED) && chatNotification) {
-                ChatMessage chatMsg = ChatMessage.fromBuild(build, buildResult, listener);
-                
-                if (isValueSet(content)) {
-                	chatMsg.setContent(vars.expand(content));
-                }
-                
-                chatMsg.setTags(vars.expand(notificationTags));
-                api.pushChatMessage(chatMsg);
-                logger.println("Flowdock: Chat notification sent successfully");
-            }
-        }
+	/**
+	 * Returns true if notifications should be performed on failure.
+	 * Default value is true.
+	 * 
+	 * @return True if notifications should be performed on failure.
+	 */
+	public boolean getNotifyFailure() {
+		return notifyMap.get(BuildResult.FAILURE);
+	}
 
-        catch(IOException ex) {
-            logger.println("Flowdock: failed to get variables from build");
-            logger.println("Flowdock: " + ex.getMessage());
-        }
+	/**
+	 * Returns true if notifications should be performed on fixed builds.
+	 * Default value is true.
+	 * 
+	 * @return True if notifications should be performed on fixed builds.
+	 */
+	public boolean getNotifyFixed() {
+		return notifyMap.get(BuildResult.FIXED);
+	}
 
-        catch(InterruptedException ex) {
-            logger.println("Flowdock: failed to get variables from build");
-            logger.println("Flowdock: " + ex.getMessage());
-        }
+	/**
+	 * Returns true if notifications should be performed on unstable builds.
+	 * Default value is true.
+	 * 
+	 * @return True if notifications should be performed on unstable builds.
+	 */
+	public boolean getNotifyUnstable() {
+		return notifyMap.get(BuildResult.UNSTABLE);
+	}
 
-        catch(FlowdockException ex) {
-            logger.println("Flowdock: failed to send notification");
-            logger.println("Flowdock: " + ex.getMessage());
-        }
+	/**
+	 * Returns true if notifications should be performed on aborted builds.
+	 * Default value is true.
+	 * 
+	 * @return True if notifications should be performed on aborted builds.
+	 */
+	public boolean getNotifyAborted() {
+		return notifyMap.get(BuildResult.ABORTED);
+	}
 
+	/**
+	 * Returns true if notifications should be performed on not built.
+	 * Default value is true.
+	 * 
+	 * @return True if notifications should be performed on not built.
+	 */
+	public boolean getNotifyNotBuilt() {
+		return notifyMap.get(BuildResult.NOT_BUILT);
+	}
 
-    }
+	public BuildStepMonitor getRequiredMonitorService() {
+		return BuildStepMonitor.NONE;
+	}
 
-    @Override
-    public DescriptorImpl getDescriptor() {
-        return (DescriptorImpl)super.getDescriptor();
-    }
+	@Override
+	public boolean needsToRunAfterFinalized() {
+		return true;
+	}
 
-    @Extension
-    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+	@Override
+	public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
+		BuildResult buildResult = BuildResult.fromBuild(build);
+		if (shouldNotify(buildResult)) {
+			notifyFlowdock(build, buildResult, listener);
+		} else {
+			listener.getLogger()
+					.println("No Flowdock notification configured for build status: " + buildResult.toString());
+		}
+		return true;
+	}
 
-        private String apiUrl = "https://api.flowdock.com";
+	public boolean shouldNotify(BuildResult buildResult) {
+		return notifyMap.get(buildResult);
+	}
 
-        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
-            return true;
-        }
+	protected void notifyFlowdock(AbstractBuild build, BuildResult buildResult, BuildListener listener) {
+		PrintStream logger = listener.getLogger();
+		try {
+			FlowdockAPI api = new FlowdockAPI(getDescriptor().apiUrl(), flowToken);
+			TeamInboxMessage msg = TeamInboxMessage.fromBuild(build, buildResult, listener);
 
-        public String getDisplayName() {
-            return "Flowdock notification";
-        }
+			EnvVars vars = build.getEnvironment(listener);
 
-        public FormValidation doTestConnection(@QueryParameter("flowToken") final String flowToken,
-            @QueryParameter("notificationTags") final String notificationTags) {
-            try {
-                FlowdockAPI api = new FlowdockAPI(apiUrl(), flowToken);
-                ChatMessage testMsg = new ChatMessage();
-                testMsg.setTags(notificationTags);
-                testMsg.setContent("Your plugin is ready!");
-                api.pushChatMessage(testMsg);
-                return FormValidation.ok("Success! Flowdock plugin can send notifications to your flow.");
-            } catch(FlowdockException ex) {
-                return FormValidation.error(ex.getMessage());
-            }
-        }
+			// Check for overrides for both content and subject
+			if (StringUtils.isNotBlank(content)) {
+				msg.setContent(vars.expand(content));
+			}
 
-        @Override
-        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
-            apiUrl = formData.getString("apiUrl");
-            save();
-            return super.configure(req, formData);
-        }
+			if (StringUtils.isNotBlank(subject)) {
+				msg.setSubject(vars.expand(subject));
+			}
 
-        public String apiUrl() {
-            return apiUrl;
-        }
-    }
+			msg.setTags(vars.expand(notificationTags));
+			api.pushTeamInboxMessage(msg);
+			listener.getLogger().println("Flowdock: Team Inbox notification sent successfully");
 
+			if ((build.getResult() != Result.SUCCESS || buildResult == BuildResult.FIXED) && chatNotification) {
+				ChatMessage chatMsg = ChatMessage.fromBuild(build, buildResult, listener);
+
+				if (StringUtils.isNotBlank(content)) {
+					chatMsg.setContent(vars.expand(content));
+				}
+
+				chatMsg.setTags(vars.expand(notificationTags));
+				api.pushChatMessage(chatMsg);
+				logger.println("Flowdock: Chat notification sent successfully");
+			}
+		}
+
+		catch (IOException ex) {
+			logger.println("Flowdock: failed to get variables from build");
+			logger.println("Flowdock: " + ex.getMessage());
+		}
+
+		catch (InterruptedException ex) {
+			logger.println("Flowdock: failed to get variables from build");
+			logger.println("Flowdock: " + ex.getMessage());
+		}
+
+		catch (FlowdockException ex) {
+			logger.println("Flowdock: failed to send notification");
+			logger.println("Flowdock: " + ex.getMessage());
+		}
+
+	}
+
+	@Override
+	public DescriptorImpl getDescriptor() {
+		return (DescriptorImpl) super.getDescriptor();
+	}
+
+	@Extension
+	public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+
+		private String apiUrl = "https://api.flowdock.com";
+
+		public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+			return true;
+		}
+
+		public String getDisplayName() {
+			return "Flowdock notification";
+		}
+
+		public FormValidation doTestConnection(@QueryParameter("flowToken") final String flowToken,
+				@QueryParameter("notificationTags") final String notificationTags) {
+			try {
+				FlowdockAPI api = new FlowdockAPI(apiUrl(), flowToken);
+				ChatMessage testMsg = new ChatMessage();
+				testMsg.setTags(notificationTags);
+				testMsg.setContent("Your plugin is ready!");
+				api.pushChatMessage(testMsg);
+				return FormValidation.ok("Success! Flowdock plugin can send notifications to your flow.");
+			} catch (FlowdockException ex) {
+				return FormValidation.error(ex.getMessage());
+			}
+		}
+
+		@Override
+		public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+			apiUrl = formData.getString("apiUrl");
+			save();
+			return super.configure(req, formData);
+		}
+
+		public String apiUrl() {
+			return apiUrl;
+		}
+	}
+
+	@CheckForNull
 	public String getSubject() {
 		return subject;
 	}
 
+	@CheckForNull
 	public String getContent() {
 		return content;
 	}
 
 	@DataBoundSetter
 	public void setSubject(String subject) {
-		this.subject = subject;
+		this.subject = StringUtils.isNotBlank(subject) ? subject : null;
 	}
 
 	@DataBoundSetter
 	public void setContent(String content) {
-		this.content = content;
+		this.content = StringUtils.isNotBlank(content) ? content : null;
 	}
 
 	@DataBoundSetter

--- a/src/main/java/com/flowdock/jenkins/FlowdockNotifier.java
+++ b/src/main/java/com/flowdock/jenkins/FlowdockNotifier.java
@@ -34,318 +34,317 @@ import net.sf.json.JSONObject;
 
 public class FlowdockNotifier extends Notifier {
 
-    private final String flowToken;
+	private final String flowToken;
 
-    private String notificationTags;
-    private boolean chatNotification;
+	private String notificationTags;
+	private boolean chatNotification;
 
-    private final Map<BuildResult, Boolean> notifyMap;
+	private final Map<BuildResult, Boolean> notifyMap;
 
-    private String subject;
-    private String content;
+	private String subject;
+	private String content;
 
-    @Deprecated
-    @Restricted(NoExternalUse.class)
-    public FlowdockNotifier(String flowToken, String notificationTags, String chatNotification, String notifySuccess,
-            String notifyFailure, String notifyFixed, String notifyUnstable, String notifyAborted,
-            String notifyNotBuilt) {
-        // Call the new constructor and get all the defaults in place
-        this(flowToken);
+	@Deprecated
+	@Restricted(NoExternalUse.class)
+	public FlowdockNotifier(String flowToken, String notificationTags, String chatNotification, String notifySuccess,
+			String notifyFailure, String notifyFixed, String notifyUnstable, String notifyAborted,
+			String notifyNotBuilt) {
+		// Call the new constructor and get all the defaults in place
+		this(flowToken);
 
-        this.notificationTags = notificationTags;
+		this.notificationTags = notificationTags;
 
-        // Deprecated API is treating the notification flags as strings, not
-        // boolean so we need
-        // this to preserve backwards compatibility
-        notifyMap.put(BuildResult.SUCCESS, notifySuccess != null && notifySuccess.equals("true"));
-        notifyMap.put(BuildResult.FAILURE, notifyFailure != null && notifyFailure.equals("true"));
-        notifyMap.put(BuildResult.FIXED, notifyFixed != null && notifyFixed.equals("true"));
-        notifyMap.put(BuildResult.UNSTABLE, notifyUnstable != null && notifyUnstable.equals("true"));
-        notifyMap.put(BuildResult.ABORTED, notifyAborted != null && notifyAborted.equals("true"));
-        notifyMap.put(BuildResult.NOT_BUILT, notifyNotBuilt != null && notifyNotBuilt.equals("true"));
-    }
+		// Deprecated API is treating the notification flags as strings, not
+		// boolean so we need
+		// this to preserve backwards compatibility
+		notifyMap.put(BuildResult.SUCCESS, notifySuccess != null && notifySuccess.equals("true"));
+		notifyMap.put(BuildResult.FAILURE, notifyFailure != null && notifyFailure.equals("true"));
+		notifyMap.put(BuildResult.FIXED, notifyFixed != null && notifyFixed.equals("true"));
+		notifyMap.put(BuildResult.UNSTABLE, notifyUnstable != null && notifyUnstable.equals("true"));
+		notifyMap.put(BuildResult.ABORTED, notifyAborted != null && notifyAborted.equals("true"));
+		notifyMap.put(BuildResult.NOT_BUILT, notifyNotBuilt != null && notifyNotBuilt.equals("true"));
+	}
 
-    // Fields in config.jelly must match the parameter names in the
-    // "DataBoundConstructor"
-    @DataBoundConstructor
-    public FlowdockNotifier(String flowToken) {
-        this.flowToken = flowToken;
+	// Fields in config.jelly must match the parameter names in the
+	// "DataBoundConstructor"
+	@DataBoundConstructor
+	public FlowdockNotifier(String flowToken) {
+		this.flowToken = flowToken;
 
-        this.chatNotification = true;
+		this.chatNotification = true;
 
-        // set notification map with defaults of true
-        this.notifyMap = new HashMap<BuildResult, Boolean>();
+		// set notification map with defaults of true
+		this.notifyMap = new HashMap<BuildResult, Boolean>();
 
-        // Default value for notifications is always true since we'd rather
-        // over-notify
-        // than under
-        for (BuildResult result : BuildResult.values()) {
-            notifyMap.put(result, true);
-        }
-    }
+		// Default value for notifications is always true since we'd rather over-notify
+		// than under
+		for (BuildResult result : BuildResult.values()) {
+			notifyMap.put(result, true);
+		}
+	}
 
-    public String getFlowToken() {
-        return flowToken;
-    }
+	public String getFlowToken() {
+		return flowToken;
+	}
 
-    public String getNotificationTags() {
-        return notificationTags;
-    }
+	public String getNotificationTags() {
+		return notificationTags;
+	}
 
-    public boolean getChatNotification() {
-        return chatNotification;
-    }
+	public boolean getChatNotification() {
+		return chatNotification;
+	}
 
-    /**
-     * Returns true if notifications should be performed on success. Default
-     * value is true.
-     * 
-     * @return True if notifications should be performed on success.
-     */
-    public boolean getNotifySuccess() {
-        return notifyMap.get(BuildResult.SUCCESS);
-    }
+	/**
+	 * Returns true if notifications should be performed on success.
+	 * Default value is true.
+	 * 
+	 * @return True if notifications should be performed on success.
+	 */
+	public boolean getNotifySuccess() {
+		return notifyMap.get(BuildResult.SUCCESS);
+	}
 
-    /**
-     * Returns true if notifications should be performed on failure. Default
-     * value is true.
-     * 
-     * @return True if notifications should be performed on failure.
-     */
-    public boolean getNotifyFailure() {
-        return notifyMap.get(BuildResult.FAILURE);
-    }
+	/**
+	 * Returns true if notifications should be performed on failure.
+	 * Default value is true.
+	 * 
+	 * @return True if notifications should be performed on failure.
+	 */
+	public boolean getNotifyFailure() {
+		return notifyMap.get(BuildResult.FAILURE);
+	}
 
-    /**
-     * Returns true if notifications should be performed on fixed builds.
-     * Default value is true.
-     * 
-     * @return True if notifications should be performed on fixed builds.
-     */
-    public boolean getNotifyFixed() {
-        return notifyMap.get(BuildResult.FIXED);
-    }
+	/**
+	 * Returns true if notifications should be performed on fixed builds.
+	 * Default value is true.
+	 * 
+	 * @return True if notifications should be performed on fixed builds.
+	 */
+	public boolean getNotifyFixed() {
+		return notifyMap.get(BuildResult.FIXED);
+	}
 
-    /**
-     * Returns true if notifications should be performed on unstable builds.
-     * Default value is true.
-     * 
-     * @return True if notifications should be performed on unstable builds.
-     */
-    public boolean getNotifyUnstable() {
-        return notifyMap.get(BuildResult.UNSTABLE);
-    }
+	/**
+	 * Returns true if notifications should be performed on unstable builds.
+	 * Default value is true.
+	 * 
+	 * @return True if notifications should be performed on unstable builds.
+	 */
+	public boolean getNotifyUnstable() {
+		return notifyMap.get(BuildResult.UNSTABLE);
+	}
 
-    /**
-     * Returns true if notifications should be performed on aborted builds.
-     * Default value is true.
-     * 
-     * @return True if notifications should be performed on aborted builds.
-     */
-    public boolean getNotifyAborted() {
-        return notifyMap.get(BuildResult.ABORTED);
-    }
+	/**
+	 * Returns true if notifications should be performed on aborted builds.
+	 * Default value is true.
+	 * 
+	 * @return True if notifications should be performed on aborted builds.
+	 */
+	public boolean getNotifyAborted() {
+		return notifyMap.get(BuildResult.ABORTED);
+	}
 
-    /**
-     * Returns true if notifications should be performed on not built. Default
-     * value is true.
-     * 
-     * @return True if notifications should be performed on not built.
-     */
-    public boolean getNotifyNotBuilt() {
-        return notifyMap.get(BuildResult.NOT_BUILT);
-    }
+	/**
+	 * Returns true if notifications should be performed on not built.
+	 * Default value is true.
+	 * 
+	 * @return True if notifications should be performed on not built.
+	 */
+	public boolean getNotifyNotBuilt() {
+		return notifyMap.get(BuildResult.NOT_BUILT);
+	}
 
-    public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.NONE;
-    }
+	public BuildStepMonitor getRequiredMonitorService() {
+		return BuildStepMonitor.NONE;
+	}
 
-    @Override
-    public boolean needsToRunAfterFinalized() {
-        return true;
-    }
+	@Override
+	public boolean needsToRunAfterFinalized() {
+		return true;
+	}
 
-    @Override
-    public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
-        BuildResult buildResult = BuildResult.fromBuild(build);
-        if (shouldNotify(buildResult)) {
-            notifyFlowdock(build, buildResult, listener);
-        } else {
-            listener.getLogger()
-                    .println("No Flowdock notification configured for build status: " + buildResult.toString());
-        }
-        return true;
-    }
+	@Override
+	public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
+		BuildResult buildResult = BuildResult.fromBuild(build);
+		if (shouldNotify(buildResult)) {
+			notifyFlowdock(build, buildResult, listener);
+		} else {
+			listener.getLogger()
+					.println("No Flowdock notification configured for build status: " + buildResult.toString());
+		}
+		return true;
+	}
 
-    public boolean shouldNotify(BuildResult buildResult) {
-        return notifyMap.get(buildResult);
-    }
+	public boolean shouldNotify(BuildResult buildResult) {
+		return notifyMap.get(buildResult);
+	}
 
-    protected void notifyFlowdock(AbstractBuild build, BuildResult buildResult, BuildListener listener) {
-        PrintStream logger = listener.getLogger();
-        try {
-            FlowdockAPI api = getFlowdockAPI();
-            TeamInboxMessage msg = teamInboxMessageFromBuild(build, buildResult, listener);
+	protected void notifyFlowdock(AbstractBuild build, BuildResult buildResult, BuildListener listener) {
+		PrintStream logger = listener.getLogger();
+		try {
+			FlowdockAPI api = getFlowdockAPI();
+			TeamInboxMessage msg = teamInboxMessageFromBuild(build, buildResult, listener);
 
-            EnvVars vars = build.getEnvironment(listener);
+			EnvVars vars = build.getEnvironment(listener);
 
-            // Check for overrides for both content and subject
-            if (StringUtils.isNotBlank(content)) {
-                msg.setContent(vars.expand(content));
-            }
+			// Check for overrides for both content and subject
+			if (StringUtils.isNotBlank(content)) {
+				msg.setContent(vars.expand(content));
+			}
 
-            if (StringUtils.isNotBlank(subject)) {
-                msg.setSubject(vars.expand(subject));
-            }
+			if (StringUtils.isNotBlank(subject)) {
+				msg.setSubject(vars.expand(subject));
+			}
 
-            msg.setTags(vars.expand(notificationTags));
-            api.pushTeamInboxMessage(msg);
-            listener.getLogger().println("Flowdock: Team Inbox notification sent successfully");
+			msg.setTags(vars.expand(notificationTags));
+			api.pushTeamInboxMessage(msg);
+			listener.getLogger().println("Flowdock: Team Inbox notification sent successfully");
 
-            if ((build.getResult() != Result.SUCCESS || buildResult == BuildResult.FIXED) && chatNotification) {
-                ChatMessage chatMsg = chatMessageFromBuild(build, buildResult, listener);
+			if ((build.getResult() != Result.SUCCESS || buildResult == BuildResult.FIXED) && chatNotification) {
+				ChatMessage chatMsg = chatMessageFromBuild(build, buildResult, listener);
 
-                if (StringUtils.isNotBlank(content)) {
-                    chatMsg.setContent(vars.expand(content));
-                }
+				if (StringUtils.isNotBlank(content)) {
+					chatMsg.setContent(vars.expand(content));
+				}
 
-                chatMsg.setTags(vars.expand(notificationTags));
-                api.pushChatMessage(chatMsg);
-                logger.println("Flowdock: Chat notification sent successfully");
-            }
-        }
+				chatMsg.setTags(vars.expand(notificationTags));
+				api.pushChatMessage(chatMsg);
+				logger.println("Flowdock: Chat notification sent successfully");
+			}
+		}
 
-        catch (IOException ex) {
-            logger.println("Flowdock: failed to get variables from build");
-            logger.println("Flowdock: " + ex.getMessage());
-        }
+		catch (IOException ex) {
+			logger.println("Flowdock: failed to get variables from build");
+			logger.println("Flowdock: " + ex.getMessage());
+		}
 
-        catch (InterruptedException ex) {
-            logger.println("Flowdock: failed to get variables from build");
-            logger.println("Flowdock: " + ex.getMessage());
-        }
+		catch (InterruptedException ex) {
+			logger.println("Flowdock: failed to get variables from build");
+			logger.println("Flowdock: " + ex.getMessage());
+		}
 
-        catch (FlowdockException ex) {
-            logger.println("Flowdock: failed to send notification");
-            logger.println("Flowdock: " + ex.getMessage());
-        }
+		catch (FlowdockException ex) {
+			logger.println("Flowdock: failed to send notification");
+			logger.println("Flowdock: " + ex.getMessage());
+		}
 
-    }
+	}
 
-    protected FlowdockAPI getFlowdockAPI() {
-        return new FlowdockAPI(getDescriptor().apiUrl(), flowToken);
-    }
+	protected FlowdockAPI getFlowdockAPI() {
+		return new FlowdockAPI(getDescriptor().apiUrl(), flowToken);
+	}
 
-    protected ChatMessage chatMessageFromBuild(AbstractBuild build, BuildResult buildResult, BuildListener listener) {
-        return ChatMessage.fromBuild(Jenkins.getInstance(), build, buildResult, listener);
-    }
+	protected ChatMessage chatMessageFromBuild(AbstractBuild build, BuildResult buildResult, BuildListener listener) {
+		return ChatMessage.fromBuild(Jenkins.getInstance(), build, buildResult, listener);
+	}
 
-    protected TeamInboxMessage teamInboxMessageFromBuild(AbstractBuild build, BuildResult buildResult,
-            BuildListener listener) throws IOException, InterruptedException {
-        return TeamInboxMessage.fromBuild(Jenkins.getInstance(), build, buildResult, listener);
-    }
+	protected TeamInboxMessage teamInboxMessageFromBuild(AbstractBuild build, BuildResult buildResult,
+			BuildListener listener) throws IOException, InterruptedException {
+		return TeamInboxMessage.fromBuild(Jenkins.getInstance(), build, buildResult, listener);
+	}
 
-    @Override
-    public DescriptorImpl getDescriptor() {
-        return (DescriptorImpl) super.getDescriptor();
-    }
+	@Override
+	public DescriptorImpl getDescriptor() {
+		return (DescriptorImpl) super.getDescriptor();
+	}
 
-    @Extension
-    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+	@Extension
+	public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
-        private String apiUrl = "https://api.flowdock.com";
+		private String apiUrl = "https://api.flowdock.com";
 
-        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
-            return true;
-        }
+		public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+			return true;
+		}
 
-        public String getDisplayName() {
-            return "Flowdock notification";
-        }
+		public String getDisplayName() {
+			return "Flowdock notification";
+		}
 
-        public FormValidation doTestConnection(@QueryParameter("flowToken") final String flowToken,
-                @QueryParameter("notificationTags") final String notificationTags) {
-            try {
-                FlowdockAPI api = new FlowdockAPI(apiUrl(), flowToken);
-                ChatMessage testMsg = new ChatMessage();
-                testMsg.setTags(notificationTags);
-                testMsg.setContent("Your plugin is ready!");
-                api.pushChatMessage(testMsg);
-                return FormValidation.ok("Success! Flowdock plugin can send notifications to your flow.");
-            } catch (FlowdockException ex) {
-                return FormValidation.error(ex.getMessage());
-            }
-        }
+		public FormValidation doTestConnection(@QueryParameter("flowToken") final String flowToken,
+				@QueryParameter("notificationTags") final String notificationTags) {
+			try {
+				FlowdockAPI api = new FlowdockAPI(apiUrl(), flowToken);
+				ChatMessage testMsg = new ChatMessage();
+				testMsg.setTags(notificationTags);
+				testMsg.setContent("Your plugin is ready!");
+				api.pushChatMessage(testMsg);
+				return FormValidation.ok("Success! Flowdock plugin can send notifications to your flow.");
+			} catch (FlowdockException ex) {
+				return FormValidation.error(ex.getMessage());
+			}
+		}
 
-        @Override
-        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
-            apiUrl = formData.getString("apiUrl");
-            save();
-            return super.configure(req, formData);
-        }
+		@Override
+		public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+			apiUrl = formData.getString("apiUrl");
+			save();
+			return super.configure(req, formData);
+		}
 
-        public String apiUrl() {
-            return apiUrl;
-        }
-    }
+		public String apiUrl() {
+			return apiUrl;
+		}
+	}
 
-    @CheckForNull
-    public String getSubject() {
-        return subject;
-    }
+	@CheckForNull
+	public String getSubject() {
+		return subject;
+	}
 
-    @CheckForNull
-    public String getContent() {
-        return content;
-    }
+	@CheckForNull
+	public String getContent() {
+		return content;
+	}
 
-    @DataBoundSetter
-    public void setSubject(String subject) {
-        this.subject = StringUtils.isNotBlank(subject) ? subject : null;
-    }
+	@DataBoundSetter
+	public void setSubject(String subject) {
+		this.subject = StringUtils.isNotBlank(subject) ? subject : null;
+	}
 
-    @DataBoundSetter
-    public void setContent(String content) {
-        this.content = StringUtils.isNotBlank(content) ? content : null;
-    }
+	@DataBoundSetter
+	public void setContent(String content) {
+		this.content = StringUtils.isNotBlank(content) ? content : null;
+	}
 
-    @DataBoundSetter
-    public void setNotifySuccess(boolean notifySuccess) {
-        notifyMap.put(BuildResult.SUCCESS, notifySuccess);
-    }
+	@DataBoundSetter
+	public void setNotifySuccess(boolean notifySuccess) {
+		notifyMap.put(BuildResult.SUCCESS, notifySuccess);
+	}
 
-    @DataBoundSetter
-    public void setNotifyFailure(boolean notifyFailure) {
-        notifyMap.put(BuildResult.FAILURE, notifyFailure);
-    }
+	@DataBoundSetter
+	public void setNotifyFailure(boolean notifyFailure) {
+		notifyMap.put(BuildResult.FAILURE, notifyFailure);
+	}
 
-    @DataBoundSetter
-    public void setNotifyFixed(boolean notifyFixed) {
-        notifyMap.put(BuildResult.FIXED, notifyFixed);
-    }
+	@DataBoundSetter
+	public void setNotifyFixed(boolean notifyFixed) {
+		notifyMap.put(BuildResult.FIXED, notifyFixed);
+	}
 
-    @DataBoundSetter
-    public void setNotifyUnstable(boolean notifyUnstable) {
-        notifyMap.put(BuildResult.UNSTABLE, notifyUnstable);
-    }
+	@DataBoundSetter
+	public void setNotifyUnstable(boolean notifyUnstable) {
+		notifyMap.put(BuildResult.UNSTABLE, notifyUnstable);
+	}
 
-    @DataBoundSetter
-    public void setNotifyAborted(boolean notifyAborted) {
-        notifyMap.put(BuildResult.ABORTED, notifyAborted);
-    }
+	@DataBoundSetter
+	public void setNotifyAborted(boolean notifyAborted) {
+		notifyMap.put(BuildResult.ABORTED, notifyAborted);
+	}
 
-    @DataBoundSetter
-    public void setNotifyNotBuilt(boolean notifyNotBuilt) {
-        notifyMap.put(BuildResult.NOT_BUILT, notifyNotBuilt);
-    }
+	@DataBoundSetter
+	public void setNotifyNotBuilt(boolean notifyNotBuilt) {
+		notifyMap.put(BuildResult.NOT_BUILT, notifyNotBuilt);
+	}
 
-    @DataBoundSetter
-    public void setNotificationTags(String notificationTags) {
-        this.notificationTags = notificationTags;
-    }
+	@DataBoundSetter
+	public void setNotificationTags(String notificationTags) {
+		this.notificationTags = notificationTags;
+	}
 
-    @DataBoundSetter
-    public void setChatNotification(boolean chatNotification) {
-        this.chatNotification = chatNotification;
-    }
+	@DataBoundSetter
+	public void setChatNotification(boolean chatNotification) {
+		this.chatNotification = chatNotification;
+	}
 }

--- a/src/main/java/com/flowdock/jenkins/FlowdockNotifier.java
+++ b/src/main/java/com/flowdock/jenkins/FlowdockNotifier.java
@@ -168,11 +168,10 @@ public class FlowdockNotifier extends Notifier {
     @Override
     public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
         BuildResult buildResult = BuildResult.fromBuild(build);
-        if (shouldNotify(buildResult)) {
+        if(shouldNotify(buildResult)) {
             notifyFlowdock(build, buildResult, listener);
         } else {
-            listener.getLogger()
-                    .println("No Flowdock notification configured for build status: " + buildResult.toString());
+            listener.getLogger().println("No Flowdock notification configured for build status: " + buildResult.toString());
         }
         return true;
     }
@@ -215,17 +214,17 @@ public class FlowdockNotifier extends Notifier {
             }
         }
 
-        catch (IOException ex) {
+        catch(IOException ex) {
             logger.println("Flowdock: failed to get variables from build");
             logger.println("Flowdock: " + ex.getMessage());
         }
 
-        catch (InterruptedException ex) {
+        catch(InterruptedException ex) {
             logger.println("Flowdock: failed to get variables from build");
             logger.println("Flowdock: " + ex.getMessage());
         }
 
-        catch (FlowdockException ex) {
+        catch(FlowdockException ex) {
             logger.println("Flowdock: failed to send notification");
             logger.println("Flowdock: " + ex.getMessage());
         }
@@ -247,7 +246,7 @@ public class FlowdockNotifier extends Notifier {
 
     @Override
     public DescriptorImpl getDescriptor() {
-        return (DescriptorImpl) super.getDescriptor();
+        return (DescriptorImpl)super.getDescriptor();
     }
 
     @Extension
@@ -264,7 +263,7 @@ public class FlowdockNotifier extends Notifier {
         }
 
         public FormValidation doTestConnection(@QueryParameter("flowToken") final String flowToken,
-                @QueryParameter("notificationTags") final String notificationTags) {
+            @QueryParameter("notificationTags") final String notificationTags) {
             try {
                 FlowdockAPI api = new FlowdockAPI(apiUrl(), flowToken);
                 ChatMessage testMsg = new ChatMessage();
@@ -272,7 +271,7 @@ public class FlowdockNotifier extends Notifier {
                 testMsg.setContent("Your plugin is ready!");
                 api.pushChatMessage(testMsg);
                 return FormValidation.ok("Success! Flowdock plugin can send notifications to your flow.");
-            } catch (FlowdockException ex) {
+            } catch(FlowdockException ex) {
                 return FormValidation.error(ex.getMessage());
             }
         }

--- a/src/main/java/com/flowdock/jenkins/TeamInboxMessage.java
+++ b/src/main/java/com/flowdock/jenkins/TeamInboxMessage.java
@@ -10,6 +10,8 @@ import hudson.model.Hudson;
 import hudson.model.Result;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.ChangeLogSet.Entry;
+import jenkins.model.Jenkins;
+
 import java.io.UnsupportedEncodingException;
 import static org.apache.commons.lang.StringEscapeUtils.escapeHtml;
 
@@ -73,7 +75,7 @@ public class TeamInboxMessage extends FlowdockMessage {
         return postData.toString();
     }
 
-    public static TeamInboxMessage fromBuild(AbstractBuild build, BuildResult buildResult, BuildListener listener) throws IOException, InterruptedException {
+    public static TeamInboxMessage fromBuild(Jenkins jenkins, AbstractBuild build, BuildResult buildResult, BuildListener listener) throws IOException, InterruptedException {
         TeamInboxMessage msg = new TeamInboxMessage();
 
         String projectName = "";
@@ -89,7 +91,7 @@ public class TeamInboxMessage extends FlowdockMessage {
         String buildNo = build.getDisplayName().replaceAll("#", "");
         msg.setSubject(projectName + " build " + buildNo + configuration + " " + buildResult.getHumanResult());
 
-        String rootUrl = Hudson.getInstance().getRootUrl();
+        String rootUrl = jenkins.getRootUrl();
         String buildLink = (rootUrl == null) ? null : rootUrl + build.getUrl();
         if(buildLink != null) msg.setLink(buildLink);
 

--- a/src/main/java/com/flowdock/jenkins/TeamInboxMessage.java
+++ b/src/main/java/com/flowdock/jenkins/TeamInboxMessage.java
@@ -18,10 +18,10 @@ import static org.apache.commons.lang.StringEscapeUtils.escapeHtml;
 public class TeamInboxMessage extends FlowdockMessage {
 
     /*
-     * Default sender email addresses for displaying Gravatar icons in build
-     * notification based on the build status. You can also setup your own email
-     * addresses and configure custom Gravatar icons for them.
-     */
+        Default sender email addresses for displaying Gravatar icons in build
+        notification based on the build status. You can also setup your own email
+        addresses and configure custom Gravatar icons for them.
+    */
     public static final String FLOWDOCK_BUILD_OK_EMAIL = "build+ok@flowdock.com";
     public static final String FLOWDOCK_BUILD_FAIL_EMAIL = "build+fail@flowdock.com";
 
@@ -75,13 +75,12 @@ public class TeamInboxMessage extends FlowdockMessage {
         return postData.toString();
     }
 
-    public static TeamInboxMessage fromBuild(Jenkins jenkins, AbstractBuild build, BuildResult buildResult,
-            BuildListener listener) throws IOException, InterruptedException {
+    public static TeamInboxMessage fromBuild(Jenkins jenkins, AbstractBuild build, BuildResult buildResult, BuildListener listener) throws IOException, InterruptedException {
         TeamInboxMessage msg = new TeamInboxMessage();
 
         String projectName = "";
         String configuration = "";
-        if (build.getProject().getRootProject() != build.getProject()) {
+        if(build.getProject().getRootProject() != build.getProject()) {
             projectName = build.getProject().getRootProject().getDisplayName();
             configuration = " on " + build.getProject().getDisplayName();
         } else {
@@ -94,37 +93,37 @@ public class TeamInboxMessage extends FlowdockMessage {
 
         String rootUrl = jenkins.getRootUrl();
         String buildLink = (rootUrl == null) ? null : rootUrl + build.getUrl();
-        if (buildLink != null)
-            msg.setLink(buildLink);
+        if(buildLink != null) msg.setLink(buildLink);
 
-        if (build.getResult().isWorseThan(Result.SUCCESS))
+        if(build.getResult().isWorseThan(Result.SUCCESS))
             msg.setFromAddress(FLOWDOCK_BUILD_FAIL_EMAIL);
 
         StringBuilder content = new StringBuilder();
         content.append("<h3>").append(projectName).append("</h3>");
         content.append("Build: ").append(build.getDisplayName()).append("<br />");
         content.append("Result: <strong>").append(buildResult.toString()).append("</strong><br />");
-        if (buildLink != null)
-            content.append("URL: <a href=\"").append(buildLink).append("\">").append(build.getFullDisplayName())
-                    .append("</a>").append("<br />");
+        if(buildLink != null)
+            content.append("URL: <a href=\"").append(buildLink).append("\">").append(build.getFullDisplayName()).append("</a>").append("<br />");
 
         EnvVars envVars = build.getEnvironment(listener);
         String vcsInfo = versionControlVariableList(envVars);
-        if (vcsInfo.length() > 0) {
+        if(vcsInfo.length() > 0) {
             content.append("<br /><strong>Version control:</strong><br />");
             content.append(vcsInfo);
             content.append("<br/>");
         }
 
         List<Entry> commits = parseCommits(build);
-        if (commits != null) {
+        if(commits != null) {
             content.append("<h3>Changes</h3><div class=\"commits\"><ul class=\"commit-list clean\">");
-            for (Entry commit : commits) {
+            for(Entry commit : commits) {
                 content.append("<li class=\"commit\"><span class=\"commit-details\">");
-                content.append("<span class=\"author-info\">").append("<span>").append(commit.getAuthor())
-                        .append("</span>").append("</span> &nbsp;");
-                content.append("<span title=\"" + commitId(commit) + "\" class=\"commit-sha\">")
-                        .append(commitId(commit, 7)).append("</span> &nbsp;");
+                content.append("<span class=\"author-info\">").
+                    append("<span>").append(commit.getAuthor()).append("</span>").
+                append("</span> &nbsp;");
+                content.append("<span title=\"" + commitId(commit) + "\" class=\"commit-sha\">").
+                    append(commitId(commit, 7)).
+                append("</span> &nbsp;");
                 content.append("<span class=\"commit-message\">").append(escapeHtml(commit.getMsg())).append("</span>");
                 content.append("</span></li>");
             }
@@ -138,7 +137,7 @@ public class TeamInboxMessage extends FlowdockMessage {
 
     public static List<Entry> parseCommits(AbstractBuild build) {
         final ChangeLogSet<? extends Entry> cs = build.getChangeSet();
-        if (cs == null || cs.isEmptySet())
+        if(cs == null || cs.isEmptySet())
             return null;
 
         List<Entry> commits = new ArrayList();
@@ -150,32 +149,32 @@ public class TeamInboxMessage extends FlowdockMessage {
     }
 
     private static String commitId(Entry commit) {
-        String id = commit.getCommitId();
-        if (id == null) {
-            return "unknown";
-        } else {
-            return id;
-        }
+      String id = commit.getCommitId();
+      if (id == null) {
+        return "unknown";
+      } else {
+        return id;
+      }
     }
 
     private static String commitId(Entry commit, int length) {
-        String id = commitId(commit);
-        return id.substring(0, Math.min(length, id.length()));
+      String id = commitId(commit);
+      return id.substring(0, Math.min(length, id.length()));
     }
 
     private static String versionControlVariableList(EnvVars envVars) {
         StringBuilder envList = new StringBuilder();
 
-        if (envVars.get("GIT_BRANCH") != null) {
+        if(envVars.get("GIT_BRANCH") != null) {
             envList.append("Git branch: ").append(envVars.get("GIT_BRANCH")).append("<br/>");
         }
-        if (envVars.get("GIT_URL") != null) {
+        if(envVars.get("GIT_URL") != null) {
             envList.append("Git URL: ").append(envVars.get("GIT_URL")).append("<br/>");
         }
-        if (envVars.get("SVN_REVISION") != null) {
+        if(envVars.get("SVN_REVISION") != null) {
             envList.append("SVN revision: ").append(envVars.get("SVN_REVISION")).append("<br/>");
         }
-        if (envVars.get("SVN_URL") != null) {
+        if(envVars.get("SVN_URL") != null) {
             envList.append("SVN URL: ").append(envVars.get("SVN_URL")).append("<br/>");
         }
 

--- a/src/main/java/com/flowdock/jenkins/TeamInboxMessage.java
+++ b/src/main/java/com/flowdock/jenkins/TeamInboxMessage.java
@@ -18,10 +18,10 @@ import static org.apache.commons.lang.StringEscapeUtils.escapeHtml;
 public class TeamInboxMessage extends FlowdockMessage {
 
     /*
-        Default sender email addresses for displaying Gravatar icons in build
-        notification based on the build status. You can also setup your own email
-        addresses and configure custom Gravatar icons for them.
-    */
+     * Default sender email addresses for displaying Gravatar icons in build
+     * notification based on the build status. You can also setup your own email
+     * addresses and configure custom Gravatar icons for them.
+     */
     public static final String FLOWDOCK_BUILD_OK_EMAIL = "build+ok@flowdock.com";
     public static final String FLOWDOCK_BUILD_FAIL_EMAIL = "build+fail@flowdock.com";
 
@@ -75,12 +75,13 @@ public class TeamInboxMessage extends FlowdockMessage {
         return postData.toString();
     }
 
-    public static TeamInboxMessage fromBuild(Jenkins jenkins, AbstractBuild build, BuildResult buildResult, BuildListener listener) throws IOException, InterruptedException {
+    public static TeamInboxMessage fromBuild(Jenkins jenkins, AbstractBuild build, BuildResult buildResult,
+            BuildListener listener) throws IOException, InterruptedException {
         TeamInboxMessage msg = new TeamInboxMessage();
 
         String projectName = "";
         String configuration = "";
-        if(build.getProject().getRootProject() != build.getProject()) {
+        if (build.getProject().getRootProject() != build.getProject()) {
             projectName = build.getProject().getRootProject().getDisplayName();
             configuration = " on " + build.getProject().getDisplayName();
         } else {
@@ -93,37 +94,37 @@ public class TeamInboxMessage extends FlowdockMessage {
 
         String rootUrl = jenkins.getRootUrl();
         String buildLink = (rootUrl == null) ? null : rootUrl + build.getUrl();
-        if(buildLink != null) msg.setLink(buildLink);
+        if (buildLink != null)
+            msg.setLink(buildLink);
 
-        if(build.getResult().isWorseThan(Result.SUCCESS))
+        if (build.getResult().isWorseThan(Result.SUCCESS))
             msg.setFromAddress(FLOWDOCK_BUILD_FAIL_EMAIL);
 
         StringBuilder content = new StringBuilder();
         content.append("<h3>").append(projectName).append("</h3>");
         content.append("Build: ").append(build.getDisplayName()).append("<br />");
         content.append("Result: <strong>").append(buildResult.toString()).append("</strong><br />");
-        if(buildLink != null)
-            content.append("URL: <a href=\"").append(buildLink).append("\">").append(build.getFullDisplayName()).append("</a>").append("<br />");
+        if (buildLink != null)
+            content.append("URL: <a href=\"").append(buildLink).append("\">").append(build.getFullDisplayName())
+                    .append("</a>").append("<br />");
 
         EnvVars envVars = build.getEnvironment(listener);
         String vcsInfo = versionControlVariableList(envVars);
-        if(vcsInfo.length() > 0) {
+        if (vcsInfo.length() > 0) {
             content.append("<br /><strong>Version control:</strong><br />");
             content.append(vcsInfo);
             content.append("<br/>");
         }
 
         List<Entry> commits = parseCommits(build);
-        if(commits != null) {
+        if (commits != null) {
             content.append("<h3>Changes</h3><div class=\"commits\"><ul class=\"commit-list clean\">");
-            for(Entry commit : commits) {
+            for (Entry commit : commits) {
                 content.append("<li class=\"commit\"><span class=\"commit-details\">");
-                content.append("<span class=\"author-info\">").
-                    append("<span>").append(commit.getAuthor()).append("</span>").
-                append("</span> &nbsp;");
-                content.append("<span title=\"" + commitId(commit) + "\" class=\"commit-sha\">").
-                    append(commitId(commit, 7)).
-                append("</span> &nbsp;");
+                content.append("<span class=\"author-info\">").append("<span>").append(commit.getAuthor())
+                        .append("</span>").append("</span> &nbsp;");
+                content.append("<span title=\"" + commitId(commit) + "\" class=\"commit-sha\">")
+                        .append(commitId(commit, 7)).append("</span> &nbsp;");
                 content.append("<span class=\"commit-message\">").append(escapeHtml(commit.getMsg())).append("</span>");
                 content.append("</span></li>");
             }
@@ -137,7 +138,7 @@ public class TeamInboxMessage extends FlowdockMessage {
 
     public static List<Entry> parseCommits(AbstractBuild build) {
         final ChangeLogSet<? extends Entry> cs = build.getChangeSet();
-        if(cs == null || cs.isEmptySet())
+        if (cs == null || cs.isEmptySet())
             return null;
 
         List<Entry> commits = new ArrayList();
@@ -149,32 +150,32 @@ public class TeamInboxMessage extends FlowdockMessage {
     }
 
     private static String commitId(Entry commit) {
-      String id = commit.getCommitId();
-      if (id == null) {
-        return "unknown";
-      } else {
-        return id;
-      }
+        String id = commit.getCommitId();
+        if (id == null) {
+            return "unknown";
+        } else {
+            return id;
+        }
     }
 
     private static String commitId(Entry commit, int length) {
-      String id = commitId(commit);
-      return id.substring(0, Math.min(length, id.length()));
+        String id = commitId(commit);
+        return id.substring(0, Math.min(length, id.length()));
     }
 
     private static String versionControlVariableList(EnvVars envVars) {
         StringBuilder envList = new StringBuilder();
 
-        if(envVars.get("GIT_BRANCH") != null) {
+        if (envVars.get("GIT_BRANCH") != null) {
             envList.append("Git branch: ").append(envVars.get("GIT_BRANCH")).append("<br/>");
         }
-        if(envVars.get("GIT_URL") != null) {
+        if (envVars.get("GIT_URL") != null) {
             envList.append("Git URL: ").append(envVars.get("GIT_URL")).append("<br/>");
         }
-        if(envVars.get("SVN_REVISION") != null) {
+        if (envVars.get("SVN_REVISION") != null) {
             envList.append("SVN revision: ").append(envVars.get("SVN_REVISION")).append("<br/>");
         }
-        if(envVars.get("SVN_URL") != null) {
+        if (envVars.get("SVN_URL") != null) {
             envList.append("SVN URL: ").append(envVars.get("SVN_URL")).append("<br/>");
         }
 

--- a/src/main/resources/com/flowdock/jenkins/FlowdockNotifier/config.jelly
+++ b/src/main/resources/com/flowdock/jenkins/FlowdockNotifier/config.jelly
@@ -41,6 +41,14 @@
         </f:entry>
       </f:section>
 
+      <f:section title="Override default content settings">
+        <f:entry title="Content" field="content">
+            <f:textbox/>
+        </f:entry>
+        <f:entry title="Subject" field="subject">
+            <f:textbox/>
+        </f:entry>
+      </f:section>
     </table>
         </td>
     </tr>

--- a/src/main/resources/com/flowdock/jenkins/FlowdockNotifier/help-content.html
+++ b/src/main/resources/com/flowdock/jenkins/FlowdockNotifier/help-content.html
@@ -1,0 +1,3 @@
+<div>
+  Specify to override the default content settings when a message is triggered by the build status.
+</div>

--- a/src/main/resources/com/flowdock/jenkins/FlowdockNotifier/help-subject.html
+++ b/src/main/resources/com/flowdock/jenkins/FlowdockNotifier/help-subject.html
@@ -1,0 +1,3 @@
+<div>
+  Specify to override the default subject line of the TeamInbox message based on the build status.
+</div>

--- a/src/test/java/com/flowdock/jenkins/BuildResultTest.java
+++ b/src/test/java/com/flowdock/jenkins/BuildResultTest.java
@@ -12,74 +12,74 @@ import hudson.model.AbstractBuild;
 import hudson.model.Result;
 
 /**
- * Unit tests for {@link BuildResult} 
+ * Unit tests for {@link BuildResult}
  *
  */
 public class BuildResultTest {
 
-	@Mock
-	private AbstractBuild build;
-	
-	@Mock
-	private AbstractBuild previousBuild;
-	
-	@Before
-	public void setup() {
-		MockitoAnnotations.initMocks(this);
-	}
-	
-	@Test
-	public void testFromBuildSuccessNoPreviousBuild() {
-		when(build.getResult()).thenReturn(Result.SUCCESS);
-		when(build.getPreviousBuild()).thenReturn(null);
-		
-		assertEquals(BuildResult.SUCCESS, BuildResult.fromBuild(build));
-	}
+    @Mock
+    private AbstractBuild build;
 
-	@Test
-	public void testFromBuildSuccessPreviousBuildFailure() {
-		when(build.getResult()).thenReturn(Result.SUCCESS);
-		when(build.getPreviousBuild()).thenReturn(previousBuild);
-		when(previousBuild.getResult()).thenReturn(Result.FAILURE);
-		
-		assertEquals(BuildResult.FIXED, BuildResult.fromBuild(build));
-	}
+    @Mock
+    private AbstractBuild previousBuild;
 
-	@Test
-	public void testFromBuildSuccessPreviousBuildUnstable() {
-		when(build.getResult()).thenReturn(Result.SUCCESS);
-		when(build.getPreviousBuild()).thenReturn(previousBuild);
-		when(previousBuild.getResult()).thenReturn(Result.UNSTABLE);
-		
-		assertEquals(BuildResult.FIXED, BuildResult.fromBuild(build));
-	}
-	
-	@Test
-	public void testFromBuildUnstable() {
-		when(build.getResult()).thenReturn(Result.UNSTABLE);
-		
-		assertEquals(BuildResult.UNSTABLE, BuildResult.fromBuild(build));
-	}
-	
-	@Test
-	public void testFromBuildAborted() {
-		when(build.getResult()).thenReturn(Result.ABORTED);
-		
-		assertEquals(BuildResult.ABORTED, BuildResult.fromBuild(build));
-	}
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
 
-	@Test
-	public void testFromBuildNotBuilt() {
-		when(build.getResult()).thenReturn(Result.NOT_BUILT);
-		
-		assertEquals(BuildResult.NOT_BUILT, BuildResult.fromBuild(build));
-	}
+    @Test
+    public void testFromBuildSuccessNoPreviousBuild() {
+        when(build.getResult()).thenReturn(Result.SUCCESS);
+        when(build.getPreviousBuild()).thenReturn(null);
 
-	@Test
-	public void testFromBuildFailure() {
-		when(build.getResult()).thenReturn(Result.FAILURE);
-		
-		assertEquals(BuildResult.FAILURE, BuildResult.fromBuild(build));
-	}
-	
+        assertEquals(BuildResult.SUCCESS, BuildResult.fromBuild(build));
+    }
+
+    @Test
+    public void testFromBuildSuccessPreviousBuildFailure() {
+        when(build.getResult()).thenReturn(Result.SUCCESS);
+        when(build.getPreviousBuild()).thenReturn(previousBuild);
+        when(previousBuild.getResult()).thenReturn(Result.FAILURE);
+
+        assertEquals(BuildResult.FIXED, BuildResult.fromBuild(build));
+    }
+
+    @Test
+    public void testFromBuildSuccessPreviousBuildUnstable() {
+        when(build.getResult()).thenReturn(Result.SUCCESS);
+        when(build.getPreviousBuild()).thenReturn(previousBuild);
+        when(previousBuild.getResult()).thenReturn(Result.UNSTABLE);
+
+        assertEquals(BuildResult.FIXED, BuildResult.fromBuild(build));
+    }
+
+    @Test
+    public void testFromBuildUnstable() {
+        when(build.getResult()).thenReturn(Result.UNSTABLE);
+
+        assertEquals(BuildResult.UNSTABLE, BuildResult.fromBuild(build));
+    }
+
+    @Test
+    public void testFromBuildAborted() {
+        when(build.getResult()).thenReturn(Result.ABORTED);
+
+        assertEquals(BuildResult.ABORTED, BuildResult.fromBuild(build));
+    }
+
+    @Test
+    public void testFromBuildNotBuilt() {
+        when(build.getResult()).thenReturn(Result.NOT_BUILT);
+
+        assertEquals(BuildResult.NOT_BUILT, BuildResult.fromBuild(build));
+    }
+
+    @Test
+    public void testFromBuildFailure() {
+        when(build.getResult()).thenReturn(Result.FAILURE);
+
+        assertEquals(BuildResult.FAILURE, BuildResult.fromBuild(build));
+    }
+
 }

--- a/src/test/java/com/flowdock/jenkins/BuildResultTest.java
+++ b/src/test/java/com/flowdock/jenkins/BuildResultTest.java
@@ -1,0 +1,85 @@
+package com.flowdock.jenkins;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Result;
+
+/**
+ * Unit tests for {@link BuildResult} 
+ *
+ */
+public class BuildResultTest {
+
+	@Mock
+	private AbstractBuild build;
+	
+	@Mock
+	private AbstractBuild previousBuild;
+	
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+	}
+	
+	@Test
+	public void testFromBuildSuccessNoPreviousBuild() {
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		when(build.getPreviousBuild()).thenReturn(null);
+		
+		assertEquals(BuildResult.SUCCESS, BuildResult.fromBuild(build));
+	}
+
+	@Test
+	public void testFromBuildSuccessPreviousBuildFailure() {
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		when(build.getPreviousBuild()).thenReturn(previousBuild);
+		when(previousBuild.getResult()).thenReturn(Result.FAILURE);
+		
+		assertEquals(BuildResult.FIXED, BuildResult.fromBuild(build));
+	}
+
+	@Test
+	public void testFromBuildSuccessPreviousBuildUnstable() {
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		when(build.getPreviousBuild()).thenReturn(previousBuild);
+		when(previousBuild.getResult()).thenReturn(Result.UNSTABLE);
+		
+		assertEquals(BuildResult.FIXED, BuildResult.fromBuild(build));
+	}
+	
+	@Test
+	public void testFromBuildUnstable() {
+		when(build.getResult()).thenReturn(Result.UNSTABLE);
+		
+		assertEquals(BuildResult.UNSTABLE, BuildResult.fromBuild(build));
+	}
+	
+	@Test
+	public void testFromBuildAborted() {
+		when(build.getResult()).thenReturn(Result.ABORTED);
+		
+		assertEquals(BuildResult.ABORTED, BuildResult.fromBuild(build));
+	}
+
+	@Test
+	public void testFromBuildNotBuilt() {
+		when(build.getResult()).thenReturn(Result.NOT_BUILT);
+		
+		assertEquals(BuildResult.NOT_BUILT, BuildResult.fromBuild(build));
+	}
+
+	@Test
+	public void testFromBuildFailure() {
+		when(build.getResult()).thenReturn(Result.FAILURE);
+		
+		assertEquals(BuildResult.FAILURE, BuildResult.fromBuild(build));
+	}
+	
+}

--- a/src/test/java/com/flowdock/jenkins/BuildResultTest.java
+++ b/src/test/java/com/flowdock/jenkins/BuildResultTest.java
@@ -12,74 +12,74 @@ import hudson.model.AbstractBuild;
 import hudson.model.Result;
 
 /**
- * Unit tests for {@link BuildResult}
+ * Unit tests for {@link BuildResult} 
  *
  */
 public class BuildResultTest {
 
-    @Mock
-    private AbstractBuild build;
+	@Mock
+	private AbstractBuild build;
+	
+	@Mock
+	private AbstractBuild previousBuild;
+	
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+	}
+	
+	@Test
+	public void testFromBuildSuccessNoPreviousBuild() {
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		when(build.getPreviousBuild()).thenReturn(null);
+		
+		assertEquals(BuildResult.SUCCESS, BuildResult.fromBuild(build));
+	}
 
-    @Mock
-    private AbstractBuild previousBuild;
+	@Test
+	public void testFromBuildSuccessPreviousBuildFailure() {
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		when(build.getPreviousBuild()).thenReturn(previousBuild);
+		when(previousBuild.getResult()).thenReturn(Result.FAILURE);
+		
+		assertEquals(BuildResult.FIXED, BuildResult.fromBuild(build));
+	}
 
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-    }
+	@Test
+	public void testFromBuildSuccessPreviousBuildUnstable() {
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		when(build.getPreviousBuild()).thenReturn(previousBuild);
+		when(previousBuild.getResult()).thenReturn(Result.UNSTABLE);
+		
+		assertEquals(BuildResult.FIXED, BuildResult.fromBuild(build));
+	}
+	
+	@Test
+	public void testFromBuildUnstable() {
+		when(build.getResult()).thenReturn(Result.UNSTABLE);
+		
+		assertEquals(BuildResult.UNSTABLE, BuildResult.fromBuild(build));
+	}
+	
+	@Test
+	public void testFromBuildAborted() {
+		when(build.getResult()).thenReturn(Result.ABORTED);
+		
+		assertEquals(BuildResult.ABORTED, BuildResult.fromBuild(build));
+	}
 
-    @Test
-    public void testFromBuildSuccessNoPreviousBuild() {
-        when(build.getResult()).thenReturn(Result.SUCCESS);
-        when(build.getPreviousBuild()).thenReturn(null);
+	@Test
+	public void testFromBuildNotBuilt() {
+		when(build.getResult()).thenReturn(Result.NOT_BUILT);
+		
+		assertEquals(BuildResult.NOT_BUILT, BuildResult.fromBuild(build));
+	}
 
-        assertEquals(BuildResult.SUCCESS, BuildResult.fromBuild(build));
-    }
-
-    @Test
-    public void testFromBuildSuccessPreviousBuildFailure() {
-        when(build.getResult()).thenReturn(Result.SUCCESS);
-        when(build.getPreviousBuild()).thenReturn(previousBuild);
-        when(previousBuild.getResult()).thenReturn(Result.FAILURE);
-
-        assertEquals(BuildResult.FIXED, BuildResult.fromBuild(build));
-    }
-
-    @Test
-    public void testFromBuildSuccessPreviousBuildUnstable() {
-        when(build.getResult()).thenReturn(Result.SUCCESS);
-        when(build.getPreviousBuild()).thenReturn(previousBuild);
-        when(previousBuild.getResult()).thenReturn(Result.UNSTABLE);
-
-        assertEquals(BuildResult.FIXED, BuildResult.fromBuild(build));
-    }
-
-    @Test
-    public void testFromBuildUnstable() {
-        when(build.getResult()).thenReturn(Result.UNSTABLE);
-
-        assertEquals(BuildResult.UNSTABLE, BuildResult.fromBuild(build));
-    }
-
-    @Test
-    public void testFromBuildAborted() {
-        when(build.getResult()).thenReturn(Result.ABORTED);
-
-        assertEquals(BuildResult.ABORTED, BuildResult.fromBuild(build));
-    }
-
-    @Test
-    public void testFromBuildNotBuilt() {
-        when(build.getResult()).thenReturn(Result.NOT_BUILT);
-
-        assertEquals(BuildResult.NOT_BUILT, BuildResult.fromBuild(build));
-    }
-
-    @Test
-    public void testFromBuildFailure() {
-        when(build.getResult()).thenReturn(Result.FAILURE);
-
-        assertEquals(BuildResult.FAILURE, BuildResult.fromBuild(build));
-    }
-
+	@Test
+	public void testFromBuildFailure() {
+		when(build.getResult()).thenReturn(Result.FAILURE);
+		
+		assertEquals(BuildResult.FAILURE, BuildResult.fromBuild(build));
+	}
+	
 }

--- a/src/test/java/com/flowdock/jenkins/ChatMessageTest.java
+++ b/src/test/java/com/flowdock/jenkins/ChatMessageTest.java
@@ -23,140 +23,147 @@ import jenkins.model.Jenkins;
  */
 public class ChatMessageTest {
 
-	@Mock
-	private AbstractBuild build;
+    @Mock
+    private AbstractBuild build;
 
-	private ChatMessage chatMessage;
-	
-	@Mock
-	private BuildListener buildListener;
+    private ChatMessage chatMessage;
 
-	@Mock
-	private AbstractProject project;
-	
-	@Mock
-	private Jenkins jenkins;
-	
-	@Before
-	public void setup() {
-		MockitoAnnotations.initMocks(this);
-		
-		// We want to make sure that things are url encoded and safe
-		chatMessage = new ChatMessage();
-		chatMessage.setContent("the&content<with>junk");
-		chatMessage.setTags(" tags<with>junk ");
-		
-		when(build.getProject()).thenReturn(project);
-		when(project.getRootProject()).thenReturn(project);
-		when(project.getDisplayName()).thenReturn("Project Name");
-		when(jenkins.getRootUrl()).thenReturn("http://localhost:8080");
-		when(build.getDisplayName()).thenReturn("Build Name");
-		when(build.getUrl()).thenReturn("/the-build-url");
-	}
-	
-	@Test
-	public void testAsPostData() throws UnsupportedEncodingException {
-		String postData = chatMessage.asPostData();
-		
-		assertNotNull(postData);
-		
-		// This is the url encoded expectation from above
-		assertEquals("content=the%26content%3Cwith%3Ejunk&external_user_name=Jenkins&tags=tags%3Cwith%3Ejunk", postData);
-	}
+    @Mock
+    private BuildListener buildListener;
 
-	@Test
-	public void testAsPostDataChangeExternalName() throws UnsupportedEncodingException {
-		chatMessage.setExternalUserName("My Name");
-		String postData = chatMessage.asPostData();
-		
-		assertNotNull(postData);
-		assertEquals("content=the%26content%3Cwith%3Ejunk&external_user_name=My+Name&tags=tags%3Cwith%3Ejunk", postData);
-	}
-	
-	@Test
-	public void testAsPostDataWithTags() throws UnsupportedEncodingException {
-		chatMessage.setTags("a-tag");
-		String postData = chatMessage.asPostData();
-		
-		assertNotNull(postData);
-		
-		// This is the url encoded expectation from above
-		assertEquals("content=the%26content%3Cwith%3Ejunk&external_user_name=Jenkins&tags=a-tag", postData);
-	}
-	
-	@Test
-	public void testFromBuildSuccess() throws UnsupportedEncodingException {
-		when(build.getResult()).thenReturn(Result.SUCCESS);
-		
-		ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.SUCCESS, buildListener);
-		
-		assertNotNull(message);
-		
-		String postData = message.asPostData();
-		
-		assertNotNull(postData);
-		assertEquals("content=%3Awhite_check_mark%3A%5BProject+Name+build+Build+Name+**was+successful**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
-				postData);
-	}
+    @Mock
+    private AbstractProject project;
 
-	@Test
-	public void testFromBuildUnstable() throws UnsupportedEncodingException {
-		when(build.getResult()).thenReturn(Result.UNSTABLE);
-		
-		ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.UNSTABLE, buildListener);
-		
-		assertNotNull(message);
-		
-		String postData = message.asPostData();
-		
-		assertNotNull(postData);
-		assertEquals("content=%3Aheavy_exclamation_mark%3A%5BProject+Name+build+Build+Name+**was+unstable**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
-				postData);
-	}
-	
-	@Test
-	public void testFromBuildFailure() throws UnsupportedEncodingException {
-		when(build.getResult()).thenReturn(Result.FAILURE);
-		
-		ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.FAILURE, buildListener);
-		
-		assertNotNull(message);
-		
-		String postData = message.asPostData();
-		
-		assertNotNull(postData);
-		assertEquals("content=%3Ax%3A%5BProject+Name+build+Build+Name+**failed**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
-				postData);
-	}
-	
-	@Test
-	public void testFromBuildAborted() throws UnsupportedEncodingException {
-		when(build.getResult()).thenReturn(Result.ABORTED);
-		
-		ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.ABORTED, buildListener);
-		
-		assertNotNull(message);
-		
-		String postData = message.asPostData();
-		
-		assertNotNull(postData);
-		assertEquals("content=%3Ano_entry_sign%3A%5BProject+Name+build+Build+Name+**was+aborted**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
-				postData);
-	}
+    @Mock
+    private Jenkins jenkins;
 
-	@Test
-	public void testFromBuildNotBuilt() throws UnsupportedEncodingException {
-		when(build.getResult()).thenReturn(Result.NOT_BUILT);
-		
-		ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.NOT_BUILT, buildListener);
-		
-		assertNotNull(message);
-		
-		String postData = message.asPostData();
-		
-		assertNotNull(postData);
-		assertEquals("content=%3Ao%3A%5BProject+Name+build+Build+Name+**was+not+built**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
-				postData);
-	}
-	
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        // We want to make sure that things are url encoded and safe
+        chatMessage = new ChatMessage();
+        chatMessage.setContent("the&content<with>junk");
+        chatMessage.setTags(" tags<with>junk ");
+
+        when(build.getProject()).thenReturn(project);
+        when(project.getRootProject()).thenReturn(project);
+        when(project.getDisplayName()).thenReturn("Project Name");
+        when(jenkins.getRootUrl()).thenReturn("http://localhost:8080");
+        when(build.getDisplayName()).thenReturn("Build Name");
+        when(build.getUrl()).thenReturn("/the-build-url");
+    }
+
+    @Test
+    public void testAsPostData() throws UnsupportedEncodingException {
+        String postData = chatMessage.asPostData();
+
+        assertNotNull(postData);
+
+        // This is the url encoded expectation from above
+        assertEquals("content=the%26content%3Cwith%3Ejunk&external_user_name=Jenkins&tags=tags%3Cwith%3Ejunk",
+                postData);
+    }
+
+    @Test
+    public void testAsPostDataChangeExternalName() throws UnsupportedEncodingException {
+        chatMessage.setExternalUserName("My Name");
+        String postData = chatMessage.asPostData();
+
+        assertNotNull(postData);
+        assertEquals("content=the%26content%3Cwith%3Ejunk&external_user_name=My+Name&tags=tags%3Cwith%3Ejunk",
+                postData);
+    }
+
+    @Test
+    public void testAsPostDataWithTags() throws UnsupportedEncodingException {
+        chatMessage.setTags("a-tag");
+        String postData = chatMessage.asPostData();
+
+        assertNotNull(postData);
+
+        // This is the url encoded expectation from above
+        assertEquals("content=the%26content%3Cwith%3Ejunk&external_user_name=Jenkins&tags=a-tag", postData);
+    }
+
+    @Test
+    public void testFromBuildSuccess() throws UnsupportedEncodingException {
+        when(build.getResult()).thenReturn(Result.SUCCESS);
+
+        ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.SUCCESS, buildListener);
+
+        assertNotNull(message);
+
+        String postData = message.asPostData();
+
+        assertNotNull(postData);
+        assertEquals(
+                "content=%3Awhite_check_mark%3A%5BProject+Name+build+Build+Name+**was+successful**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
+                postData);
+    }
+
+    @Test
+    public void testFromBuildUnstable() throws UnsupportedEncodingException {
+        when(build.getResult()).thenReturn(Result.UNSTABLE);
+
+        ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.UNSTABLE, buildListener);
+
+        assertNotNull(message);
+
+        String postData = message.asPostData();
+
+        assertNotNull(postData);
+        assertEquals(
+                "content=%3Aheavy_exclamation_mark%3A%5BProject+Name+build+Build+Name+**was+unstable**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
+                postData);
+    }
+
+    @Test
+    public void testFromBuildFailure() throws UnsupportedEncodingException {
+        when(build.getResult()).thenReturn(Result.FAILURE);
+
+        ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.FAILURE, buildListener);
+
+        assertNotNull(message);
+
+        String postData = message.asPostData();
+
+        assertNotNull(postData);
+        assertEquals(
+                "content=%3Ax%3A%5BProject+Name+build+Build+Name+**failed**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
+                postData);
+    }
+
+    @Test
+    public void testFromBuildAborted() throws UnsupportedEncodingException {
+        when(build.getResult()).thenReturn(Result.ABORTED);
+
+        ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.ABORTED, buildListener);
+
+        assertNotNull(message);
+
+        String postData = message.asPostData();
+
+        assertNotNull(postData);
+        assertEquals(
+                "content=%3Ano_entry_sign%3A%5BProject+Name+build+Build+Name+**was+aborted**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
+                postData);
+    }
+
+    @Test
+    public void testFromBuildNotBuilt() throws UnsupportedEncodingException {
+        when(build.getResult()).thenReturn(Result.NOT_BUILT);
+
+        ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.NOT_BUILT, buildListener);
+
+        assertNotNull(message);
+
+        String postData = message.asPostData();
+
+        assertNotNull(postData);
+        assertEquals(
+                "content=%3Ao%3A%5BProject+Name+build+Build+Name+**was+not+built**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
+                postData);
+    }
+
 }

--- a/src/test/java/com/flowdock/jenkins/ChatMessageTest.java
+++ b/src/test/java/com/flowdock/jenkins/ChatMessageTest.java
@@ -1,0 +1,162 @@
+package com.flowdock.jenkins;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.io.UnsupportedEncodingException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import jenkins.model.Jenkins;
+
+/**
+ * Unit tests for {@link ChatMessage}
+ * 
+ */
+public class ChatMessageTest {
+
+	@Mock
+	private AbstractBuild build;
+
+	private ChatMessage chatMessage;
+	
+	@Mock
+	private BuildListener buildListener;
+
+	@Mock
+	private AbstractProject project;
+	
+	@Mock
+	private Jenkins jenkins;
+	
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		
+		// We want to make sure that things are url encoded and safe
+		chatMessage = new ChatMessage();
+		chatMessage.setContent("the&content<with>junk");
+		chatMessage.setTags(" tags<with>junk ");
+		
+		when(build.getProject()).thenReturn(project);
+		when(project.getRootProject()).thenReturn(project);
+		when(project.getDisplayName()).thenReturn("Project Name");
+		when(jenkins.getRootUrl()).thenReturn("http://localhost:8080");
+		when(build.getDisplayName()).thenReturn("Build Name");
+		when(build.getUrl()).thenReturn("/the-build-url");
+	}
+	
+	@Test
+	public void testAsPostData() throws UnsupportedEncodingException {
+		String postData = chatMessage.asPostData();
+		
+		assertNotNull(postData);
+		
+		// This is the url encoded expectation from above
+		assertEquals("content=the%26content%3Cwith%3Ejunk&external_user_name=Jenkins&tags=tags%3Cwith%3Ejunk", postData);
+	}
+
+	@Test
+	public void testAsPostDataChangeExternalName() throws UnsupportedEncodingException {
+		chatMessage.setExternalUserName("My Name");
+		String postData = chatMessage.asPostData();
+		
+		assertNotNull(postData);
+		assertEquals("content=the%26content%3Cwith%3Ejunk&external_user_name=My+Name&tags=tags%3Cwith%3Ejunk", postData);
+	}
+	
+	@Test
+	public void testAsPostDataWithTags() throws UnsupportedEncodingException {
+		chatMessage.setTags("a-tag");
+		String postData = chatMessage.asPostData();
+		
+		assertNotNull(postData);
+		
+		// This is the url encoded expectation from above
+		assertEquals("content=the%26content%3Cwith%3Ejunk&external_user_name=Jenkins&tags=a-tag", postData);
+	}
+	
+	@Test
+	public void testFromBuildSuccess() throws UnsupportedEncodingException {
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		
+		ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.SUCCESS, buildListener);
+		
+		assertNotNull(message);
+		
+		String postData = message.asPostData();
+		
+		assertNotNull(postData);
+		assertEquals("content=%3Awhite_check_mark%3A%5BProject+Name+build+Build+Name+**was+successful**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
+				postData);
+	}
+
+	@Test
+	public void testFromBuildUnstable() throws UnsupportedEncodingException {
+		when(build.getResult()).thenReturn(Result.UNSTABLE);
+		
+		ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.UNSTABLE, buildListener);
+		
+		assertNotNull(message);
+		
+		String postData = message.asPostData();
+		
+		assertNotNull(postData);
+		assertEquals("content=%3Aheavy_exclamation_mark%3A%5BProject+Name+build+Build+Name+**was+unstable**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
+				postData);
+	}
+	
+	@Test
+	public void testFromBuildFailure() throws UnsupportedEncodingException {
+		when(build.getResult()).thenReturn(Result.FAILURE);
+		
+		ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.FAILURE, buildListener);
+		
+		assertNotNull(message);
+		
+		String postData = message.asPostData();
+		
+		assertNotNull(postData);
+		assertEquals("content=%3Ax%3A%5BProject+Name+build+Build+Name+**failed**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
+				postData);
+	}
+	
+	@Test
+	public void testFromBuildAborted() throws UnsupportedEncodingException {
+		when(build.getResult()).thenReturn(Result.ABORTED);
+		
+		ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.ABORTED, buildListener);
+		
+		assertNotNull(message);
+		
+		String postData = message.asPostData();
+		
+		assertNotNull(postData);
+		assertEquals("content=%3Ano_entry_sign%3A%5BProject+Name+build+Build+Name+**was+aborted**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
+				postData);
+	}
+
+	@Test
+	public void testFromBuildNotBuilt() throws UnsupportedEncodingException {
+		when(build.getResult()).thenReturn(Result.NOT_BUILT);
+		
+		ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.NOT_BUILT, buildListener);
+		
+		assertNotNull(message);
+		
+		String postData = message.asPostData();
+		
+		assertNotNull(postData);
+		assertEquals("content=%3Ao%3A%5BProject+Name+build+Build+Name+**was+not+built**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
+				postData);
+	}
+	
+}

--- a/src/test/java/com/flowdock/jenkins/ChatMessageTest.java
+++ b/src/test/java/com/flowdock/jenkins/ChatMessageTest.java
@@ -23,147 +23,140 @@ import jenkins.model.Jenkins;
  */
 public class ChatMessageTest {
 
-    @Mock
-    private AbstractBuild build;
+	@Mock
+	private AbstractBuild build;
 
-    private ChatMessage chatMessage;
+	private ChatMessage chatMessage;
+	
+	@Mock
+	private BuildListener buildListener;
 
-    @Mock
-    private BuildListener buildListener;
+	@Mock
+	private AbstractProject project;
+	
+	@Mock
+	private Jenkins jenkins;
+	
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		
+		// We want to make sure that things are url encoded and safe
+		chatMessage = new ChatMessage();
+		chatMessage.setContent("the&content<with>junk");
+		chatMessage.setTags(" tags<with>junk ");
+		
+		when(build.getProject()).thenReturn(project);
+		when(project.getRootProject()).thenReturn(project);
+		when(project.getDisplayName()).thenReturn("Project Name");
+		when(jenkins.getRootUrl()).thenReturn("http://localhost:8080");
+		when(build.getDisplayName()).thenReturn("Build Name");
+		when(build.getUrl()).thenReturn("/the-build-url");
+	}
+	
+	@Test
+	public void testAsPostData() throws UnsupportedEncodingException {
+		String postData = chatMessage.asPostData();
+		
+		assertNotNull(postData);
+		
+		// This is the url encoded expectation from above
+		assertEquals("content=the%26content%3Cwith%3Ejunk&external_user_name=Jenkins&tags=tags%3Cwith%3Ejunk", postData);
+	}
 
-    @Mock
-    private AbstractProject project;
+	@Test
+	public void testAsPostDataChangeExternalName() throws UnsupportedEncodingException {
+		chatMessage.setExternalUserName("My Name");
+		String postData = chatMessage.asPostData();
+		
+		assertNotNull(postData);
+		assertEquals("content=the%26content%3Cwith%3Ejunk&external_user_name=My+Name&tags=tags%3Cwith%3Ejunk", postData);
+	}
+	
+	@Test
+	public void testAsPostDataWithTags() throws UnsupportedEncodingException {
+		chatMessage.setTags("a-tag");
+		String postData = chatMessage.asPostData();
+		
+		assertNotNull(postData);
+		
+		// This is the url encoded expectation from above
+		assertEquals("content=the%26content%3Cwith%3Ejunk&external_user_name=Jenkins&tags=a-tag", postData);
+	}
+	
+	@Test
+	public void testFromBuildSuccess() throws UnsupportedEncodingException {
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		
+		ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.SUCCESS, buildListener);
+		
+		assertNotNull(message);
+		
+		String postData = message.asPostData();
+		
+		assertNotNull(postData);
+		assertEquals("content=%3Awhite_check_mark%3A%5BProject+Name+build+Build+Name+**was+successful**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
+				postData);
+	}
 
-    @Mock
-    private Jenkins jenkins;
+	@Test
+	public void testFromBuildUnstable() throws UnsupportedEncodingException {
+		when(build.getResult()).thenReturn(Result.UNSTABLE);
+		
+		ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.UNSTABLE, buildListener);
+		
+		assertNotNull(message);
+		
+		String postData = message.asPostData();
+		
+		assertNotNull(postData);
+		assertEquals("content=%3Aheavy_exclamation_mark%3A%5BProject+Name+build+Build+Name+**was+unstable**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
+				postData);
+	}
+	
+	@Test
+	public void testFromBuildFailure() throws UnsupportedEncodingException {
+		when(build.getResult()).thenReturn(Result.FAILURE);
+		
+		ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.FAILURE, buildListener);
+		
+		assertNotNull(message);
+		
+		String postData = message.asPostData();
+		
+		assertNotNull(postData);
+		assertEquals("content=%3Ax%3A%5BProject+Name+build+Build+Name+**failed**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
+				postData);
+	}
+	
+	@Test
+	public void testFromBuildAborted() throws UnsupportedEncodingException {
+		when(build.getResult()).thenReturn(Result.ABORTED);
+		
+		ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.ABORTED, buildListener);
+		
+		assertNotNull(message);
+		
+		String postData = message.asPostData();
+		
+		assertNotNull(postData);
+		assertEquals("content=%3Ano_entry_sign%3A%5BProject+Name+build+Build+Name+**was+aborted**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
+				postData);
+	}
 
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-
-        // We want to make sure that things are url encoded and safe
-        chatMessage = new ChatMessage();
-        chatMessage.setContent("the&content<with>junk");
-        chatMessage.setTags(" tags<with>junk ");
-
-        when(build.getProject()).thenReturn(project);
-        when(project.getRootProject()).thenReturn(project);
-        when(project.getDisplayName()).thenReturn("Project Name");
-        when(jenkins.getRootUrl()).thenReturn("http://localhost:8080");
-        when(build.getDisplayName()).thenReturn("Build Name");
-        when(build.getUrl()).thenReturn("/the-build-url");
-    }
-
-    @Test
-    public void testAsPostData() throws UnsupportedEncodingException {
-        String postData = chatMessage.asPostData();
-
-        assertNotNull(postData);
-
-        // This is the url encoded expectation from above
-        assertEquals("content=the%26content%3Cwith%3Ejunk&external_user_name=Jenkins&tags=tags%3Cwith%3Ejunk",
-                postData);
-    }
-
-    @Test
-    public void testAsPostDataChangeExternalName() throws UnsupportedEncodingException {
-        chatMessage.setExternalUserName("My Name");
-        String postData = chatMessage.asPostData();
-
-        assertNotNull(postData);
-        assertEquals("content=the%26content%3Cwith%3Ejunk&external_user_name=My+Name&tags=tags%3Cwith%3Ejunk",
-                postData);
-    }
-
-    @Test
-    public void testAsPostDataWithTags() throws UnsupportedEncodingException {
-        chatMessage.setTags("a-tag");
-        String postData = chatMessage.asPostData();
-
-        assertNotNull(postData);
-
-        // This is the url encoded expectation from above
-        assertEquals("content=the%26content%3Cwith%3Ejunk&external_user_name=Jenkins&tags=a-tag", postData);
-    }
-
-    @Test
-    public void testFromBuildSuccess() throws UnsupportedEncodingException {
-        when(build.getResult()).thenReturn(Result.SUCCESS);
-
-        ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.SUCCESS, buildListener);
-
-        assertNotNull(message);
-
-        String postData = message.asPostData();
-
-        assertNotNull(postData);
-        assertEquals(
-                "content=%3Awhite_check_mark%3A%5BProject+Name+build+Build+Name+**was+successful**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
-                postData);
-    }
-
-    @Test
-    public void testFromBuildUnstable() throws UnsupportedEncodingException {
-        when(build.getResult()).thenReturn(Result.UNSTABLE);
-
-        ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.UNSTABLE, buildListener);
-
-        assertNotNull(message);
-
-        String postData = message.asPostData();
-
-        assertNotNull(postData);
-        assertEquals(
-                "content=%3Aheavy_exclamation_mark%3A%5BProject+Name+build+Build+Name+**was+unstable**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
-                postData);
-    }
-
-    @Test
-    public void testFromBuildFailure() throws UnsupportedEncodingException {
-        when(build.getResult()).thenReturn(Result.FAILURE);
-
-        ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.FAILURE, buildListener);
-
-        assertNotNull(message);
-
-        String postData = message.asPostData();
-
-        assertNotNull(postData);
-        assertEquals(
-                "content=%3Ax%3A%5BProject+Name+build+Build+Name+**failed**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
-                postData);
-    }
-
-    @Test
-    public void testFromBuildAborted() throws UnsupportedEncodingException {
-        when(build.getResult()).thenReturn(Result.ABORTED);
-
-        ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.ABORTED, buildListener);
-
-        assertNotNull(message);
-
-        String postData = message.asPostData();
-
-        assertNotNull(postData);
-        assertEquals(
-                "content=%3Ano_entry_sign%3A%5BProject+Name+build+Build+Name+**was+aborted**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
-                postData);
-    }
-
-    @Test
-    public void testFromBuildNotBuilt() throws UnsupportedEncodingException {
-        when(build.getResult()).thenReturn(Result.NOT_BUILT);
-
-        ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.NOT_BUILT, buildListener);
-
-        assertNotNull(message);
-
-        String postData = message.asPostData();
-
-        assertNotNull(postData);
-        assertEquals(
-                "content=%3Ao%3A%5BProject+Name+build+Build+Name+**was+not+built**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
-                postData);
-    }
-
+	@Test
+	public void testFromBuildNotBuilt() throws UnsupportedEncodingException {
+		when(build.getResult()).thenReturn(Result.NOT_BUILT);
+		
+		ChatMessage message = chatMessage.fromBuild(jenkins, build, BuildResult.NOT_BUILT, buildListener);
+		
+		assertNotNull(message);
+		
+		String postData = message.asPostData();
+		
+		assertNotNull(postData);
+		assertEquals("content=%3Ao%3A%5BProject+Name+build+Build+Name+**was+not+built**%5D%28http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%29&external_user_name=Jenkins&tags=",
+				postData);
+	}
+	
 }

--- a/src/test/java/com/flowdock/jenkins/FlowdockAPITest.java
+++ b/src/test/java/com/flowdock/jenkins/FlowdockAPITest.java
@@ -24,98 +24,98 @@ import com.flowdock.jenkins.exception.FlowdockException;
  */
 public class FlowdockAPITest {
 
-    @Mock
-    private HttpURLConnection connection;
+	@Mock
+	private HttpURLConnection connection;
+	
+	private String url = "http://localhost";
+	
+	private String token = "the token";
 
-    private String url = "http://localhost";
+	private FlowdockAPI api;
+	
+	@Mock
+	private TeamInboxMessage teamInboxMessage;
+	
+	@Mock
+	private ChatMessage chatMessage;
+	
+	private ByteArrayOutputStream outputStream;
+	
+	@Before
+	public void setup() throws Exception {
+		MockitoAnnotations.initMocks(this);
+		
+		outputStream = new ByteArrayOutputStream();
 
-    private String token = "the token";
+		api = new FlowdockAPI(url, token) {
+			@Override
+			protected HttpURLConnection getConnection(URL url) throws IOException {
+				assertTrue(url.toString().startsWith("http://localhost"));
+				return connection;
+			}
+		};
 
-    private FlowdockAPI api;
+		when(teamInboxMessage.asPostData()).thenReturn("team-message");
+		when(chatMessage.asPostData()).thenReturn("chat-message");
+		
+		when(connection.getOutputStream()).thenReturn(outputStream);
+	}
+	
+	@Test
+	public void testPushTeamInboxMessageSuccess() throws Exception {
+		api = new FlowdockAPI(url, token) {
+			@Override
+			protected HttpURLConnection getConnection(URL url) throws IOException {
+				assertEquals("http://localhost/messages/team_inbox/thetoken", url.toString());
+				return connection;
+			}
+		};
+		
+		when(connection.getResponseCode()).thenReturn(200);
+		
+		api.pushTeamInboxMessage(teamInboxMessage);
+		
+		verify(connection).setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+		verify(connection).setRequestProperty("Content-Length", String.valueOf("team-message".length()));
+		verify(connection).setRequestMethod("POST");
 
-    @Mock
-    private TeamInboxMessage teamInboxMessage;
+		assertEquals(teamInboxMessage.asPostData(), new String(outputStream.toByteArray(), "UTF-8"));
+	}
 
-    @Mock
-    private ChatMessage chatMessage;
+	@Test
+	public void testPushChatMessageSuccess() throws Exception {
+		api = new FlowdockAPI(url, token) {
+			@Override
+			protected HttpURLConnection getConnection(URL url) throws IOException {
+				assertEquals("http://localhost/messages/chat/thetoken", url.toString());
+				return connection;
+			}
+		};
+		
+		when(connection.getResponseCode()).thenReturn(200);
+		
+		api.pushChatMessage(chatMessage);
+		
+		verify(connection).setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+		verify(connection).setRequestProperty("Content-Length", String.valueOf("chat-message".length()));
+		verify(connection).setRequestMethod("POST");
 
-    private ByteArrayOutputStream outputStream;
-
-    @Before
-    public void setup() throws Exception {
-        MockitoAnnotations.initMocks(this);
-
-        outputStream = new ByteArrayOutputStream();
-
-        api = new FlowdockAPI(url, token) {
-            @Override
-            protected HttpURLConnection getConnection(URL url) throws IOException {
-                assertTrue(url.toString().startsWith("http://localhost"));
-                return connection;
-            }
-        };
-
-        when(teamInboxMessage.asPostData()).thenReturn("team-message");
-        when(chatMessage.asPostData()).thenReturn("chat-message");
-
-        when(connection.getOutputStream()).thenReturn(outputStream);
-    }
-
-    @Test
-    public void testPushTeamInboxMessageSuccess() throws Exception {
-        api = new FlowdockAPI(url, token) {
-            @Override
-            protected HttpURLConnection getConnection(URL url) throws IOException {
-                assertEquals("http://localhost/messages/team_inbox/thetoken", url.toString());
-                return connection;
-            }
-        };
-
-        when(connection.getResponseCode()).thenReturn(200);
-
-        api.pushTeamInboxMessage(teamInboxMessage);
-
-        verify(connection).setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
-        verify(connection).setRequestProperty("Content-Length", String.valueOf("team-message".length()));
-        verify(connection).setRequestMethod("POST");
-
-        assertEquals(teamInboxMessage.asPostData(), new String(outputStream.toByteArray(), "UTF-8"));
-    }
-
-    @Test
-    public void testPushChatMessageSuccess() throws Exception {
-        api = new FlowdockAPI(url, token) {
-            @Override
-            protected HttpURLConnection getConnection(URL url) throws IOException {
-                assertEquals("http://localhost/messages/chat/thetoken", url.toString());
-                return connection;
-            }
-        };
-
-        when(connection.getResponseCode()).thenReturn(200);
-
-        api.pushChatMessage(chatMessage);
-
-        verify(connection).setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
-        verify(connection).setRequestProperty("Content-Length", String.valueOf("chat-message".length()));
-        verify(connection).setRequestMethod("POST");
-
-        assertEquals(chatMessage.asPostData(), new String(outputStream.toByteArray(), "UTF-8"));
-    }
-
-    @Test(expected = FlowdockException.class)
-    public void testPushTeamInboxMessageFailure() throws Exception {
-        api = new FlowdockAPI(url, token) {
-            @Override
-            protected HttpURLConnection getConnection(URL url) throws IOException {
-                assertEquals("http://localhost/messages/team_inbox/thetoken", url.toString());
-                return connection;
-            }
-        };
-
-        when(connection.getResponseCode()).thenReturn(500);
-
-        api.pushTeamInboxMessage(teamInboxMessage);
-    }
-
+		assertEquals(chatMessage.asPostData(), new String(outputStream.toByteArray(), "UTF-8"));
+	}
+	
+	@Test(expected=FlowdockException.class)
+	public void testPushTeamInboxMessageFailure() throws Exception {
+		api = new FlowdockAPI(url, token) {
+			@Override
+			protected HttpURLConnection getConnection(URL url) throws IOException {
+				assertEquals("http://localhost/messages/team_inbox/thetoken", url.toString());
+				return connection;
+			}
+		};
+		
+		when(connection.getResponseCode()).thenReturn(500);
+		
+		api.pushTeamInboxMessage(teamInboxMessage);
+	}
+	
 }

--- a/src/test/java/com/flowdock/jenkins/FlowdockAPITest.java
+++ b/src/test/java/com/flowdock/jenkins/FlowdockAPITest.java
@@ -24,98 +24,98 @@ import com.flowdock.jenkins.exception.FlowdockException;
  */
 public class FlowdockAPITest {
 
-	@Mock
-	private HttpURLConnection connection;
-	
-	private String url = "http://localhost";
-	
-	private String token = "the token";
+    @Mock
+    private HttpURLConnection connection;
 
-	private FlowdockAPI api;
-	
-	@Mock
-	private TeamInboxMessage teamInboxMessage;
-	
-	@Mock
-	private ChatMessage chatMessage;
-	
-	private ByteArrayOutputStream outputStream;
-	
-	@Before
-	public void setup() throws Exception {
-		MockitoAnnotations.initMocks(this);
-		
-		outputStream = new ByteArrayOutputStream();
+    private String url = "http://localhost";
 
-		api = new FlowdockAPI(url, token) {
-			@Override
-			protected HttpURLConnection getConnection(URL url) throws IOException {
-				assertTrue(url.toString().startsWith("http://localhost"));
-				return connection;
-			}
-		};
+    private String token = "the token";
 
-		when(teamInboxMessage.asPostData()).thenReturn("team-message");
-		when(chatMessage.asPostData()).thenReturn("chat-message");
-		
-		when(connection.getOutputStream()).thenReturn(outputStream);
-	}
-	
-	@Test
-	public void testPushTeamInboxMessageSuccess() throws Exception {
-		api = new FlowdockAPI(url, token) {
-			@Override
-			protected HttpURLConnection getConnection(URL url) throws IOException {
-				assertEquals("http://localhost/messages/team_inbox/thetoken", url.toString());
-				return connection;
-			}
-		};
-		
-		when(connection.getResponseCode()).thenReturn(200);
-		
-		api.pushTeamInboxMessage(teamInboxMessage);
-		
-		verify(connection).setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
-		verify(connection).setRequestProperty("Content-Length", String.valueOf("team-message".length()));
-		verify(connection).setRequestMethod("POST");
+    private FlowdockAPI api;
 
-		assertEquals(teamInboxMessage.asPostData(), new String(outputStream.toByteArray(), "UTF-8"));
-	}
+    @Mock
+    private TeamInboxMessage teamInboxMessage;
 
-	@Test
-	public void testPushChatMessageSuccess() throws Exception {
-		api = new FlowdockAPI(url, token) {
-			@Override
-			protected HttpURLConnection getConnection(URL url) throws IOException {
-				assertEquals("http://localhost/messages/chat/thetoken", url.toString());
-				return connection;
-			}
-		};
-		
-		when(connection.getResponseCode()).thenReturn(200);
-		
-		api.pushChatMessage(chatMessage);
-		
-		verify(connection).setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
-		verify(connection).setRequestProperty("Content-Length", String.valueOf("chat-message".length()));
-		verify(connection).setRequestMethod("POST");
+    @Mock
+    private ChatMessage chatMessage;
 
-		assertEquals(chatMessage.asPostData(), new String(outputStream.toByteArray(), "UTF-8"));
-	}
-	
-	@Test(expected=FlowdockException.class)
-	public void testPushTeamInboxMessageFailure() throws Exception {
-		api = new FlowdockAPI(url, token) {
-			@Override
-			protected HttpURLConnection getConnection(URL url) throws IOException {
-				assertEquals("http://localhost/messages/team_inbox/thetoken", url.toString());
-				return connection;
-			}
-		};
-		
-		when(connection.getResponseCode()).thenReturn(500);
-		
-		api.pushTeamInboxMessage(teamInboxMessage);
-	}
-	
+    private ByteArrayOutputStream outputStream;
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        outputStream = new ByteArrayOutputStream();
+
+        api = new FlowdockAPI(url, token) {
+            @Override
+            protected HttpURLConnection getConnection(URL url) throws IOException {
+                assertTrue(url.toString().startsWith("http://localhost"));
+                return connection;
+            }
+        };
+
+        when(teamInboxMessage.asPostData()).thenReturn("team-message");
+        when(chatMessage.asPostData()).thenReturn("chat-message");
+
+        when(connection.getOutputStream()).thenReturn(outputStream);
+    }
+
+    @Test
+    public void testPushTeamInboxMessageSuccess() throws Exception {
+        api = new FlowdockAPI(url, token) {
+            @Override
+            protected HttpURLConnection getConnection(URL url) throws IOException {
+                assertEquals("http://localhost/messages/team_inbox/thetoken", url.toString());
+                return connection;
+            }
+        };
+
+        when(connection.getResponseCode()).thenReturn(200);
+
+        api.pushTeamInboxMessage(teamInboxMessage);
+
+        verify(connection).setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+        verify(connection).setRequestProperty("Content-Length", String.valueOf("team-message".length()));
+        verify(connection).setRequestMethod("POST");
+
+        assertEquals(teamInboxMessage.asPostData(), new String(outputStream.toByteArray(), "UTF-8"));
+    }
+
+    @Test
+    public void testPushChatMessageSuccess() throws Exception {
+        api = new FlowdockAPI(url, token) {
+            @Override
+            protected HttpURLConnection getConnection(URL url) throws IOException {
+                assertEquals("http://localhost/messages/chat/thetoken", url.toString());
+                return connection;
+            }
+        };
+
+        when(connection.getResponseCode()).thenReturn(200);
+
+        api.pushChatMessage(chatMessage);
+
+        verify(connection).setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+        verify(connection).setRequestProperty("Content-Length", String.valueOf("chat-message".length()));
+        verify(connection).setRequestMethod("POST");
+
+        assertEquals(chatMessage.asPostData(), new String(outputStream.toByteArray(), "UTF-8"));
+    }
+
+    @Test(expected = FlowdockException.class)
+    public void testPushTeamInboxMessageFailure() throws Exception {
+        api = new FlowdockAPI(url, token) {
+            @Override
+            protected HttpURLConnection getConnection(URL url) throws IOException {
+                assertEquals("http://localhost/messages/team_inbox/thetoken", url.toString());
+                return connection;
+            }
+        };
+
+        when(connection.getResponseCode()).thenReturn(500);
+
+        api.pushTeamInboxMessage(teamInboxMessage);
+    }
+
 }

--- a/src/test/java/com/flowdock/jenkins/FlowdockAPITest.java
+++ b/src/test/java/com/flowdock/jenkins/FlowdockAPITest.java
@@ -1,0 +1,121 @@
+package com.flowdock.jenkins;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.ProtocolException;
+import java.net.URL;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.flowdock.jenkins.exception.FlowdockException;
+
+/**
+ * Unit tests for {@link FlowdockAPI}
+ *
+ */
+public class FlowdockAPITest {
+
+	@Mock
+	private HttpURLConnection connection;
+	
+	private String url = "http://localhost";
+	
+	private String token = "the token";
+
+	private FlowdockAPI api;
+	
+	@Mock
+	private TeamInboxMessage teamInboxMessage;
+	
+	@Mock
+	private ChatMessage chatMessage;
+	
+	private ByteArrayOutputStream outputStream;
+	
+	@Before
+	public void setup() throws Exception {
+		MockitoAnnotations.initMocks(this);
+		
+		outputStream = new ByteArrayOutputStream();
+
+		api = new FlowdockAPI(url, token) {
+			@Override
+			protected HttpURLConnection getConnection(URL url) throws IOException {
+				assertTrue(url.toString().startsWith("http://localhost"));
+				return connection;
+			}
+		};
+
+		when(teamInboxMessage.asPostData()).thenReturn("team-message");
+		when(chatMessage.asPostData()).thenReturn("chat-message");
+		
+		when(connection.getOutputStream()).thenReturn(outputStream);
+	}
+	
+	@Test
+	public void testPushTeamInboxMessageSuccess() throws Exception {
+		api = new FlowdockAPI(url, token) {
+			@Override
+			protected HttpURLConnection getConnection(URL url) throws IOException {
+				assertEquals("http://localhost/messages/team_inbox/thetoken", url.toString());
+				return connection;
+			}
+		};
+		
+		when(connection.getResponseCode()).thenReturn(200);
+		
+		api.pushTeamInboxMessage(teamInboxMessage);
+		
+		verify(connection).setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+		verify(connection).setRequestProperty("Content-Length", String.valueOf("team-message".length()));
+		verify(connection).setRequestMethod("POST");
+
+		assertEquals(teamInboxMessage.asPostData(), new String(outputStream.toByteArray(), "UTF-8"));
+	}
+
+	@Test
+	public void testPushChatMessageSuccess() throws Exception {
+		api = new FlowdockAPI(url, token) {
+			@Override
+			protected HttpURLConnection getConnection(URL url) throws IOException {
+				assertEquals("http://localhost/messages/chat/thetoken", url.toString());
+				return connection;
+			}
+		};
+		
+		when(connection.getResponseCode()).thenReturn(200);
+		
+		api.pushChatMessage(chatMessage);
+		
+		verify(connection).setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+		verify(connection).setRequestProperty("Content-Length", String.valueOf("chat-message".length()));
+		verify(connection).setRequestMethod("POST");
+
+		assertEquals(chatMessage.asPostData(), new String(outputStream.toByteArray(), "UTF-8"));
+	}
+	
+	@Test(expected=FlowdockException.class)
+	public void testPushTeamInboxMessageFailure() throws Exception {
+		api = new FlowdockAPI(url, token) {
+			@Override
+			protected HttpURLConnection getConnection(URL url) throws IOException {
+				assertEquals("http://localhost/messages/team_inbox/thetoken", url.toString());
+				return connection;
+			}
+		};
+		
+		when(connection.getResponseCode()).thenReturn(500);
+		
+		api.pushTeamInboxMessage(teamInboxMessage);
+	}
+	
+}

--- a/src/test/java/com/flowdock/jenkins/FlowdockNotifierTest.java
+++ b/src/test/java/com/flowdock/jenkins/FlowdockNotifierTest.java
@@ -34,193 +34,194 @@ import hudson.tasks.BuildStepMonitor;
  */
 public class FlowdockNotifierTest {
 
-    private static final String TOKEN = "the-token";
+	private static final String TOKEN = "the-token";
+	
+	private FlowdockNotifier notifier;
+	
+	@Mock
+	private AbstractBuild build;
+	
+	@Mock
+	private Launcher launcher;
+	
+	@Mock
+	private BuildListener listener;
+	
+	private PrintStream printStream;
+	
+	private DescriptorImpl descriptor;
+	
+	@Mock
+	private ChatMessage chatMessage;
+	
+	@Mock
+	private TeamInboxMessage teamInboxMessage;
+	
+	@Mock
+	private EnvVars envVars;
+	
+	@Mock
+	private FlowdockAPI flowdockAPI;
+	
+	@Before
+	public void setup() throws IOException, InterruptedException {
+		MockitoAnnotations.initMocks(this);
+	
+		descriptor = new DescriptorImpl();
+		
+		notifier = new FlowdockNotifier(TOKEN) {
+			@Override
+			public DescriptorImpl getDescriptor() {
+				return descriptor;
+			}
+			
+			@Override
+			protected ChatMessage chatMessageFromBuild(AbstractBuild build, BuildResult buildResult,
+					BuildListener listener) {
+				return chatMessage;
+			}
+			
+			@Override
+			protected TeamInboxMessage teamInboxMessageFromBuild(AbstractBuild build, BuildResult buildResult,
+					BuildListener listener) throws IOException, InterruptedException {
+				return teamInboxMessage;
+			}
+			
+			@Override
+			protected FlowdockAPI getFlowdockAPI() {
+				return flowdockAPI;
+			}
+		};
+	
+		printStream = new PrintStream(new ByteArrayOutputStream());
+		when(listener.getLogger()).thenReturn(printStream);
+		
+		when(build.getEnvironment(listener)).thenReturn(envVars);
+	}
+	
+	@Test
+	public void testNeedsToRunAfterFinalized() {
+		assertTrue(notifier.needsToRunAfterFinalized());
+	}
 
-    private FlowdockNotifier notifier;
+	@Test
+	public void testDefaultBehaviors() {
+		assertEquals(TOKEN, notifier.getFlowToken());
+		assertNull(notifier.getContent());
+		assertNull(notifier.getSubject());
+		assertNull(notifier.getNotificationTags());
+		assertTrue(notifier.getChatNotification());
+		assertTrue(notifier.getNotifyAborted());
+		assertTrue(notifier.getNotifyFailure());
+		assertTrue(notifier.getNotifyFixed());
+		assertTrue(notifier.getNotifyNotBuilt());
+		assertTrue(notifier.getNotifySuccess());
+		assertTrue(notifier.getNotifyUnstable());
+	}
+	
+	@Test
+	public void testLegacyConstructor() {
+		String chatNotification = "true";
+		String notifySuccess = "false";
+		String notifyFailure = "false";
+		String notifyFixed = "";
+		String notifyUnstable = null;
+		String notifyAborted = "not-a-value";
+		String notifyNotBuilt = "true";
+		
+		notifier = new FlowdockNotifier(TOKEN, "tags", chatNotification,
+				notifySuccess, notifyFailure, notifyFixed, notifyUnstable, notifyAborted, 
+				notifyNotBuilt);
+		
+		assertTrue(notifier.getChatNotification());
+		assertFalse(notifier.getNotifySuccess());
+		assertFalse(notifier.getNotifyFailure());
+		assertFalse(notifier.getNotifyFixed());
+		assertFalse(notifier.getNotifyUnstable());
+		assertFalse(notifier.getNotifyAborted());
+		assertTrue(notifier.getNotifyNotBuilt());
+		
+		assertEquals("tags", notifier.getNotificationTags());
+		assertEquals(TOKEN, notifier.getFlowToken());
+	}
+	
+	@Test
+	public void testSubjectAndContent() {
+		notifier.setSubject("the-subject");
+		notifier.setContent("the-content");
+		
+		assertEquals("the-subject", notifier.getSubject());
+		assertEquals("the-content", notifier.getContent());
+	}
+	
+	@Test
+	public void testGetRequiredMonitorService() {
+		assertSame(BuildStepMonitor.NONE, notifier.getRequiredMonitorService());
+	}
+	
+	@Test
+	public void testPerformSuccessTraditionalBehavior() throws Exception {
+		notifier.setNotificationTags("unexpanded-tags");
+		when(envVars.expand("unexpanded-tags")).thenReturn("expanded-tags");
 
-    @Mock
-    private AbstractBuild build;
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		
+		assertTrue(notifier.perform(build, launcher, listener));
+		
+		ArgumentCaptor<TeamInboxMessage> captor = ArgumentCaptor.forClass(TeamInboxMessage.class);
+		verify(flowdockAPI).pushTeamInboxMessage(captor.capture());
+		assertSame(teamInboxMessage, captor.getValue());
+		
+		verify(teamInboxMessage).setTags("expanded-tags");
+	}
+	
+	@Test
+	public void testPerformSuccessWithContentAndSubject() throws Exception {
+		notifier.setContent("unexpanded-content");
+		notifier.setSubject("unexpanded-subject");
+		
+		when(envVars.expand("unexpanded-content")).thenReturn("expanded-content");
+		when(envVars.expand("unexpanded-subject")).thenReturn("expanded-subject");
 
-    @Mock
-    private Launcher launcher;
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		
+		assertTrue(notifier.perform(build, launcher, listener));
+		
+		ArgumentCaptor<TeamInboxMessage> captor = ArgumentCaptor.forClass(TeamInboxMessage.class);
+		verify(flowdockAPI).pushTeamInboxMessage(captor.capture());
+		assertSame(teamInboxMessage, captor.getValue());
+		
+		verify(teamInboxMessage).setContent("expanded-content");
+		verify(teamInboxMessage).setSubject("expanded-subject");
+	}
 
-    @Mock
-    private BuildListener listener;
+	@Test
+	public void testPerformFailure() throws Exception {
+		when(build.getResult()).thenReturn(Result.FAILURE);
+		
+		assertTrue(notifier.perform(build, launcher, listener));
+		
+		verify(flowdockAPI).pushTeamInboxMessage(any(TeamInboxMessage.class));
+		verify(flowdockAPI).pushChatMessage(any(ChatMessage.class));
 
-    private PrintStream printStream;
+	}
 
-    private DescriptorImpl descriptor;
+	@Test
+	public void testPerformFailureWithContent() throws Exception {
+		notifier.setContent("unexpanded-content");
+		notifier.setSubject("unexpanded-subject");
+		
+		when(envVars.expand("unexpanded-content")).thenReturn("expanded-content");
+		when(envVars.expand("unexpanded-subject")).thenReturn("expanded-subject");
+		
+		when(build.getResult()).thenReturn(Result.FAILURE);
+		
+		assertTrue(notifier.perform(build, launcher, listener));
+		
+		verify(flowdockAPI).pushTeamInboxMessage(any(TeamInboxMessage.class));
+		verify(flowdockAPI).pushChatMessage(any(ChatMessage.class));
 
-    @Mock
-    private ChatMessage chatMessage;
-
-    @Mock
-    private TeamInboxMessage teamInboxMessage;
-
-    @Mock
-    private EnvVars envVars;
-
-    @Mock
-    private FlowdockAPI flowdockAPI;
-
-    @Before
-    public void setup() throws IOException, InterruptedException {
-        MockitoAnnotations.initMocks(this);
-
-        descriptor = new DescriptorImpl();
-
-        notifier = new FlowdockNotifier(TOKEN) {
-            @Override
-            public DescriptorImpl getDescriptor() {
-                return descriptor;
-            }
-
-            @Override
-            protected ChatMessage chatMessageFromBuild(AbstractBuild build, BuildResult buildResult,
-                    BuildListener listener) {
-                return chatMessage;
-            }
-
-            @Override
-            protected TeamInboxMessage teamInboxMessageFromBuild(AbstractBuild build, BuildResult buildResult,
-                    BuildListener listener) throws IOException, InterruptedException {
-                return teamInboxMessage;
-            }
-
-            @Override
-            protected FlowdockAPI getFlowdockAPI() {
-                return flowdockAPI;
-            }
-        };
-
-        printStream = new PrintStream(new ByteArrayOutputStream());
-        when(listener.getLogger()).thenReturn(printStream);
-
-        when(build.getEnvironment(listener)).thenReturn(envVars);
-    }
-
-    @Test
-    public void testNeedsToRunAfterFinalized() {
-        assertTrue(notifier.needsToRunAfterFinalized());
-    }
-
-    @Test
-    public void testDefaultBehaviors() {
-        assertEquals(TOKEN, notifier.getFlowToken());
-        assertNull(notifier.getContent());
-        assertNull(notifier.getSubject());
-        assertNull(notifier.getNotificationTags());
-        assertTrue(notifier.getChatNotification());
-        assertTrue(notifier.getNotifyAborted());
-        assertTrue(notifier.getNotifyFailure());
-        assertTrue(notifier.getNotifyFixed());
-        assertTrue(notifier.getNotifyNotBuilt());
-        assertTrue(notifier.getNotifySuccess());
-        assertTrue(notifier.getNotifyUnstable());
-    }
-
-    @Test
-    public void testLegacyConstructor() {
-        String chatNotification = "true";
-        String notifySuccess = "false";
-        String notifyFailure = "false";
-        String notifyFixed = "";
-        String notifyUnstable = null;
-        String notifyAborted = "not-a-value";
-        String notifyNotBuilt = "true";
-
-        notifier = new FlowdockNotifier(TOKEN, "tags", chatNotification, notifySuccess, notifyFailure, notifyFixed,
-                notifyUnstable, notifyAborted, notifyNotBuilt);
-
-        assertTrue(notifier.getChatNotification());
-        assertFalse(notifier.getNotifySuccess());
-        assertFalse(notifier.getNotifyFailure());
-        assertFalse(notifier.getNotifyFixed());
-        assertFalse(notifier.getNotifyUnstable());
-        assertFalse(notifier.getNotifyAborted());
-        assertTrue(notifier.getNotifyNotBuilt());
-
-        assertEquals("tags", notifier.getNotificationTags());
-        assertEquals(TOKEN, notifier.getFlowToken());
-    }
-
-    @Test
-    public void testSubjectAndContent() {
-        notifier.setSubject("the-subject");
-        notifier.setContent("the-content");
-
-        assertEquals("the-subject", notifier.getSubject());
-        assertEquals("the-content", notifier.getContent());
-    }
-
-    @Test
-    public void testGetRequiredMonitorService() {
-        assertSame(BuildStepMonitor.NONE, notifier.getRequiredMonitorService());
-    }
-
-    @Test
-    public void testPerformSuccessTraditionalBehavior() throws Exception {
-        notifier.setNotificationTags("unexpanded-tags");
-        when(envVars.expand("unexpanded-tags")).thenReturn("expanded-tags");
-
-        when(build.getResult()).thenReturn(Result.SUCCESS);
-
-        assertTrue(notifier.perform(build, launcher, listener));
-
-        ArgumentCaptor<TeamInboxMessage> captor = ArgumentCaptor.forClass(TeamInboxMessage.class);
-        verify(flowdockAPI).pushTeamInboxMessage(captor.capture());
-        assertSame(teamInboxMessage, captor.getValue());
-
-        verify(teamInboxMessage).setTags("expanded-tags");
-    }
-
-    @Test
-    public void testPerformSuccessWithContentAndSubject() throws Exception {
-        notifier.setContent("unexpanded-content");
-        notifier.setSubject("unexpanded-subject");
-
-        when(envVars.expand("unexpanded-content")).thenReturn("expanded-content");
-        when(envVars.expand("unexpanded-subject")).thenReturn("expanded-subject");
-
-        when(build.getResult()).thenReturn(Result.SUCCESS);
-
-        assertTrue(notifier.perform(build, launcher, listener));
-
-        ArgumentCaptor<TeamInboxMessage> captor = ArgumentCaptor.forClass(TeamInboxMessage.class);
-        verify(flowdockAPI).pushTeamInboxMessage(captor.capture());
-        assertSame(teamInboxMessage, captor.getValue());
-
-        verify(teamInboxMessage).setContent("expanded-content");
-        verify(teamInboxMessage).setSubject("expanded-subject");
-    }
-
-    @Test
-    public void testPerformFailure() throws Exception {
-        when(build.getResult()).thenReturn(Result.FAILURE);
-
-        assertTrue(notifier.perform(build, launcher, listener));
-
-        verify(flowdockAPI).pushTeamInboxMessage(any(TeamInboxMessage.class));
-        verify(flowdockAPI).pushChatMessage(any(ChatMessage.class));
-
-    }
-
-    @Test
-    public void testPerformFailureWithContent() throws Exception {
-        notifier.setContent("unexpanded-content");
-        notifier.setSubject("unexpanded-subject");
-
-        when(envVars.expand("unexpanded-content")).thenReturn("expanded-content");
-        when(envVars.expand("unexpanded-subject")).thenReturn("expanded-subject");
-
-        when(build.getResult()).thenReturn(Result.FAILURE);
-
-        assertTrue(notifier.perform(build, launcher, listener));
-
-        verify(flowdockAPI).pushTeamInboxMessage(any(TeamInboxMessage.class));
-        verify(flowdockAPI).pushChatMessage(any(ChatMessage.class));
-
-        verify(chatMessage).setContent("expanded-content");
-    }
-
+		verify(chatMessage).setContent("expanded-content");
+	}
+	
 }

--- a/src/test/java/com/flowdock/jenkins/FlowdockNotifierTest.java
+++ b/src/test/java/com/flowdock/jenkins/FlowdockNotifierTest.java
@@ -1,0 +1,227 @@
+package com.flowdock.jenkins;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.flowdock.jenkins.FlowdockNotifier.DescriptorImpl;
+
+import hudson.EnvVars;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.tasks.BuildStepMonitor;
+
+/**
+ * Unit tests for {@link FlowdockNotifier}
+ * 
+ */
+public class FlowdockNotifierTest {
+
+	private static final String TOKEN = "the-token";
+	
+	private FlowdockNotifier notifier;
+	
+	@Mock
+	private AbstractBuild build;
+	
+	@Mock
+	private Launcher launcher;
+	
+	@Mock
+	private BuildListener listener;
+	
+	private PrintStream printStream;
+	
+	private DescriptorImpl descriptor;
+	
+	@Mock
+	private ChatMessage chatMessage;
+	
+	@Mock
+	private TeamInboxMessage teamInboxMessage;
+	
+	@Mock
+	private EnvVars envVars;
+	
+	@Mock
+	private FlowdockAPI flowdockAPI;
+	
+	@Before
+	public void setup() throws IOException, InterruptedException {
+		MockitoAnnotations.initMocks(this);
+	
+		descriptor = new DescriptorImpl();
+		
+		notifier = new FlowdockNotifier(TOKEN) {
+			@Override
+			public DescriptorImpl getDescriptor() {
+				return descriptor;
+			}
+			
+			@Override
+			protected ChatMessage chatMessageFromBuild(AbstractBuild build, BuildResult buildResult,
+					BuildListener listener) {
+				return chatMessage;
+			}
+			
+			@Override
+			protected TeamInboxMessage teamInboxMessageFromBuild(AbstractBuild build, BuildResult buildResult,
+					BuildListener listener) throws IOException, InterruptedException {
+				return teamInboxMessage;
+			}
+			
+			@Override
+			protected FlowdockAPI getFlowdockAPI() {
+				return flowdockAPI;
+			}
+		};
+	
+		printStream = new PrintStream(new ByteArrayOutputStream());
+		when(listener.getLogger()).thenReturn(printStream);
+		
+		when(build.getEnvironment(listener)).thenReturn(envVars);
+	}
+	
+	@Test
+	public void testNeedsToRunAfterFinalized() {
+		assertTrue(notifier.needsToRunAfterFinalized());
+	}
+
+	@Test
+	public void testDefaultBehaviors() {
+		assertEquals(TOKEN, notifier.getFlowToken());
+		assertNull(notifier.getContent());
+		assertNull(notifier.getSubject());
+		assertNull(notifier.getNotificationTags());
+		assertTrue(notifier.getChatNotification());
+		assertTrue(notifier.getNotifyAborted());
+		assertTrue(notifier.getNotifyFailure());
+		assertTrue(notifier.getNotifyFixed());
+		assertTrue(notifier.getNotifyNotBuilt());
+		assertTrue(notifier.getNotifySuccess());
+		assertTrue(notifier.getNotifyUnstable());
+	}
+	
+	@Test
+	public void testLegacyConstructor() {
+		String chatNotification = "true";
+		String notifySuccess = "false";
+		String notifyFailure = "false";
+		String notifyFixed = "";
+		String notifyUnstable = null;
+		String notifyAborted = "not-a-value";
+		String notifyNotBuilt = "true";
+		
+		notifier = new FlowdockNotifier(TOKEN, "tags", chatNotification,
+				notifySuccess, notifyFailure, notifyFixed, notifyUnstable, notifyAborted, 
+				notifyNotBuilt);
+		
+		assertTrue(notifier.getChatNotification());
+		assertFalse(notifier.getNotifySuccess());
+		assertFalse(notifier.getNotifyFailure());
+		assertFalse(notifier.getNotifyFixed());
+		assertFalse(notifier.getNotifyUnstable());
+		assertFalse(notifier.getNotifyAborted());
+		assertTrue(notifier.getNotifyNotBuilt());
+		
+		assertEquals("tags", notifier.getNotificationTags());
+		assertEquals(TOKEN, notifier.getFlowToken());
+	}
+	
+	@Test
+	public void testSubjectAndContent() {
+		notifier.setSubject("the-subject");
+		notifier.setContent("the-content");
+		
+		assertEquals("the-subject", notifier.getSubject());
+		assertEquals("the-content", notifier.getContent());
+	}
+	
+	@Test
+	public void testGetRequiredMonitorService() {
+		assertSame(BuildStepMonitor.NONE, notifier.getRequiredMonitorService());
+	}
+	
+	@Test
+	public void testPerformSuccessTraditionalBehavior() throws Exception {
+		notifier.setNotificationTags("unexpanded-tags");
+		when(envVars.expand("unexpanded-tags")).thenReturn("expanded-tags");
+
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		
+		assertTrue(notifier.perform(build, launcher, listener));
+		
+		ArgumentCaptor<TeamInboxMessage> captor = ArgumentCaptor.forClass(TeamInboxMessage.class);
+		verify(flowdockAPI).pushTeamInboxMessage(captor.capture());
+		assertSame(teamInboxMessage, captor.getValue());
+		
+		verify(teamInboxMessage).setTags("expanded-tags");
+	}
+	
+	@Test
+	public void testPerformSuccessWithContentAndSubject() throws Exception {
+		notifier.setContent("unexpanded-content");
+		notifier.setSubject("unexpanded-subject");
+		
+		when(envVars.expand("unexpanded-content")).thenReturn("expanded-content");
+		when(envVars.expand("unexpanded-subject")).thenReturn("expanded-subject");
+
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		
+		assertTrue(notifier.perform(build, launcher, listener));
+		
+		ArgumentCaptor<TeamInboxMessage> captor = ArgumentCaptor.forClass(TeamInboxMessage.class);
+		verify(flowdockAPI).pushTeamInboxMessage(captor.capture());
+		assertSame(teamInboxMessage, captor.getValue());
+		
+		verify(teamInboxMessage).setContent("expanded-content");
+		verify(teamInboxMessage).setSubject("expanded-subject");
+	}
+
+	@Test
+	public void testPerformFailure() throws Exception {
+		when(build.getResult()).thenReturn(Result.FAILURE);
+		
+		assertTrue(notifier.perform(build, launcher, listener));
+		
+		verify(flowdockAPI).pushTeamInboxMessage(any(TeamInboxMessage.class));
+		verify(flowdockAPI).pushChatMessage(any(ChatMessage.class));
+
+	}
+
+	@Test
+	public void testPerformFailureWithContent() throws Exception {
+		notifier.setContent("unexpanded-content");
+		notifier.setSubject("unexpanded-subject");
+		
+		when(envVars.expand("unexpanded-content")).thenReturn("expanded-content");
+		when(envVars.expand("unexpanded-subject")).thenReturn("expanded-subject");
+		
+		when(build.getResult()).thenReturn(Result.FAILURE);
+		
+		assertTrue(notifier.perform(build, launcher, listener));
+		
+		verify(flowdockAPI).pushTeamInboxMessage(any(TeamInboxMessage.class));
+		verify(flowdockAPI).pushChatMessage(any(ChatMessage.class));
+
+		verify(chatMessage).setContent("expanded-content");
+	}
+	
+}

--- a/src/test/java/com/flowdock/jenkins/FlowdockNotifierTest.java
+++ b/src/test/java/com/flowdock/jenkins/FlowdockNotifierTest.java
@@ -34,194 +34,193 @@ import hudson.tasks.BuildStepMonitor;
  */
 public class FlowdockNotifierTest {
 
-	private static final String TOKEN = "the-token";
-	
-	private FlowdockNotifier notifier;
-	
-	@Mock
-	private AbstractBuild build;
-	
-	@Mock
-	private Launcher launcher;
-	
-	@Mock
-	private BuildListener listener;
-	
-	private PrintStream printStream;
-	
-	private DescriptorImpl descriptor;
-	
-	@Mock
-	private ChatMessage chatMessage;
-	
-	@Mock
-	private TeamInboxMessage teamInboxMessage;
-	
-	@Mock
-	private EnvVars envVars;
-	
-	@Mock
-	private FlowdockAPI flowdockAPI;
-	
-	@Before
-	public void setup() throws IOException, InterruptedException {
-		MockitoAnnotations.initMocks(this);
-	
-		descriptor = new DescriptorImpl();
-		
-		notifier = new FlowdockNotifier(TOKEN) {
-			@Override
-			public DescriptorImpl getDescriptor() {
-				return descriptor;
-			}
-			
-			@Override
-			protected ChatMessage chatMessageFromBuild(AbstractBuild build, BuildResult buildResult,
-					BuildListener listener) {
-				return chatMessage;
-			}
-			
-			@Override
-			protected TeamInboxMessage teamInboxMessageFromBuild(AbstractBuild build, BuildResult buildResult,
-					BuildListener listener) throws IOException, InterruptedException {
-				return teamInboxMessage;
-			}
-			
-			@Override
-			protected FlowdockAPI getFlowdockAPI() {
-				return flowdockAPI;
-			}
-		};
-	
-		printStream = new PrintStream(new ByteArrayOutputStream());
-		when(listener.getLogger()).thenReturn(printStream);
-		
-		when(build.getEnvironment(listener)).thenReturn(envVars);
-	}
-	
-	@Test
-	public void testNeedsToRunAfterFinalized() {
-		assertTrue(notifier.needsToRunAfterFinalized());
-	}
+    private static final String TOKEN = "the-token";
 
-	@Test
-	public void testDefaultBehaviors() {
-		assertEquals(TOKEN, notifier.getFlowToken());
-		assertNull(notifier.getContent());
-		assertNull(notifier.getSubject());
-		assertNull(notifier.getNotificationTags());
-		assertTrue(notifier.getChatNotification());
-		assertTrue(notifier.getNotifyAborted());
-		assertTrue(notifier.getNotifyFailure());
-		assertTrue(notifier.getNotifyFixed());
-		assertTrue(notifier.getNotifyNotBuilt());
-		assertTrue(notifier.getNotifySuccess());
-		assertTrue(notifier.getNotifyUnstable());
-	}
-	
-	@Test
-	public void testLegacyConstructor() {
-		String chatNotification = "true";
-		String notifySuccess = "false";
-		String notifyFailure = "false";
-		String notifyFixed = "";
-		String notifyUnstable = null;
-		String notifyAborted = "not-a-value";
-		String notifyNotBuilt = "true";
-		
-		notifier = new FlowdockNotifier(TOKEN, "tags", chatNotification,
-				notifySuccess, notifyFailure, notifyFixed, notifyUnstable, notifyAborted, 
-				notifyNotBuilt);
-		
-		assertTrue(notifier.getChatNotification());
-		assertFalse(notifier.getNotifySuccess());
-		assertFalse(notifier.getNotifyFailure());
-		assertFalse(notifier.getNotifyFixed());
-		assertFalse(notifier.getNotifyUnstable());
-		assertFalse(notifier.getNotifyAborted());
-		assertTrue(notifier.getNotifyNotBuilt());
-		
-		assertEquals("tags", notifier.getNotificationTags());
-		assertEquals(TOKEN, notifier.getFlowToken());
-	}
-	
-	@Test
-	public void testSubjectAndContent() {
-		notifier.setSubject("the-subject");
-		notifier.setContent("the-content");
-		
-		assertEquals("the-subject", notifier.getSubject());
-		assertEquals("the-content", notifier.getContent());
-	}
-	
-	@Test
-	public void testGetRequiredMonitorService() {
-		assertSame(BuildStepMonitor.NONE, notifier.getRequiredMonitorService());
-	}
-	
-	@Test
-	public void testPerformSuccessTraditionalBehavior() throws Exception {
-		notifier.setNotificationTags("unexpanded-tags");
-		when(envVars.expand("unexpanded-tags")).thenReturn("expanded-tags");
+    private FlowdockNotifier notifier;
 
-		when(build.getResult()).thenReturn(Result.SUCCESS);
-		
-		assertTrue(notifier.perform(build, launcher, listener));
-		
-		ArgumentCaptor<TeamInboxMessage> captor = ArgumentCaptor.forClass(TeamInboxMessage.class);
-		verify(flowdockAPI).pushTeamInboxMessage(captor.capture());
-		assertSame(teamInboxMessage, captor.getValue());
-		
-		verify(teamInboxMessage).setTags("expanded-tags");
-	}
-	
-	@Test
-	public void testPerformSuccessWithContentAndSubject() throws Exception {
-		notifier.setContent("unexpanded-content");
-		notifier.setSubject("unexpanded-subject");
-		
-		when(envVars.expand("unexpanded-content")).thenReturn("expanded-content");
-		when(envVars.expand("unexpanded-subject")).thenReturn("expanded-subject");
+    @Mock
+    private AbstractBuild build;
 
-		when(build.getResult()).thenReturn(Result.SUCCESS);
-		
-		assertTrue(notifier.perform(build, launcher, listener));
-		
-		ArgumentCaptor<TeamInboxMessage> captor = ArgumentCaptor.forClass(TeamInboxMessage.class);
-		verify(flowdockAPI).pushTeamInboxMessage(captor.capture());
-		assertSame(teamInboxMessage, captor.getValue());
-		
-		verify(teamInboxMessage).setContent("expanded-content");
-		verify(teamInboxMessage).setSubject("expanded-subject");
-	}
+    @Mock
+    private Launcher launcher;
 
-	@Test
-	public void testPerformFailure() throws Exception {
-		when(build.getResult()).thenReturn(Result.FAILURE);
-		
-		assertTrue(notifier.perform(build, launcher, listener));
-		
-		verify(flowdockAPI).pushTeamInboxMessage(any(TeamInboxMessage.class));
-		verify(flowdockAPI).pushChatMessage(any(ChatMessage.class));
+    @Mock
+    private BuildListener listener;
 
-	}
+    private PrintStream printStream;
 
-	@Test
-	public void testPerformFailureWithContent() throws Exception {
-		notifier.setContent("unexpanded-content");
-		notifier.setSubject("unexpanded-subject");
-		
-		when(envVars.expand("unexpanded-content")).thenReturn("expanded-content");
-		when(envVars.expand("unexpanded-subject")).thenReturn("expanded-subject");
-		
-		when(build.getResult()).thenReturn(Result.FAILURE);
-		
-		assertTrue(notifier.perform(build, launcher, listener));
-		
-		verify(flowdockAPI).pushTeamInboxMessage(any(TeamInboxMessage.class));
-		verify(flowdockAPI).pushChatMessage(any(ChatMessage.class));
+    private DescriptorImpl descriptor;
 
-		verify(chatMessage).setContent("expanded-content");
-	}
-	
+    @Mock
+    private ChatMessage chatMessage;
+
+    @Mock
+    private TeamInboxMessage teamInboxMessage;
+
+    @Mock
+    private EnvVars envVars;
+
+    @Mock
+    private FlowdockAPI flowdockAPI;
+
+    @Before
+    public void setup() throws IOException, InterruptedException {
+        MockitoAnnotations.initMocks(this);
+
+        descriptor = new DescriptorImpl();
+
+        notifier = new FlowdockNotifier(TOKEN) {
+            @Override
+            public DescriptorImpl getDescriptor() {
+                return descriptor;
+            }
+
+            @Override
+            protected ChatMessage chatMessageFromBuild(AbstractBuild build, BuildResult buildResult,
+                    BuildListener listener) {
+                return chatMessage;
+            }
+
+            @Override
+            protected TeamInboxMessage teamInboxMessageFromBuild(AbstractBuild build, BuildResult buildResult,
+                    BuildListener listener) throws IOException, InterruptedException {
+                return teamInboxMessage;
+            }
+
+            @Override
+            protected FlowdockAPI getFlowdockAPI() {
+                return flowdockAPI;
+            }
+        };
+
+        printStream = new PrintStream(new ByteArrayOutputStream());
+        when(listener.getLogger()).thenReturn(printStream);
+
+        when(build.getEnvironment(listener)).thenReturn(envVars);
+    }
+
+    @Test
+    public void testNeedsToRunAfterFinalized() {
+        assertTrue(notifier.needsToRunAfterFinalized());
+    }
+
+    @Test
+    public void testDefaultBehaviors() {
+        assertEquals(TOKEN, notifier.getFlowToken());
+        assertNull(notifier.getContent());
+        assertNull(notifier.getSubject());
+        assertNull(notifier.getNotificationTags());
+        assertTrue(notifier.getChatNotification());
+        assertTrue(notifier.getNotifyAborted());
+        assertTrue(notifier.getNotifyFailure());
+        assertTrue(notifier.getNotifyFixed());
+        assertTrue(notifier.getNotifyNotBuilt());
+        assertTrue(notifier.getNotifySuccess());
+        assertTrue(notifier.getNotifyUnstable());
+    }
+
+    @Test
+    public void testLegacyConstructor() {
+        String chatNotification = "true";
+        String notifySuccess = "false";
+        String notifyFailure = "false";
+        String notifyFixed = "";
+        String notifyUnstable = null;
+        String notifyAborted = "not-a-value";
+        String notifyNotBuilt = "true";
+
+        notifier = new FlowdockNotifier(TOKEN, "tags", chatNotification, notifySuccess, notifyFailure, notifyFixed,
+                notifyUnstable, notifyAborted, notifyNotBuilt);
+
+        assertTrue(notifier.getChatNotification());
+        assertFalse(notifier.getNotifySuccess());
+        assertFalse(notifier.getNotifyFailure());
+        assertFalse(notifier.getNotifyFixed());
+        assertFalse(notifier.getNotifyUnstable());
+        assertFalse(notifier.getNotifyAborted());
+        assertTrue(notifier.getNotifyNotBuilt());
+
+        assertEquals("tags", notifier.getNotificationTags());
+        assertEquals(TOKEN, notifier.getFlowToken());
+    }
+
+    @Test
+    public void testSubjectAndContent() {
+        notifier.setSubject("the-subject");
+        notifier.setContent("the-content");
+
+        assertEquals("the-subject", notifier.getSubject());
+        assertEquals("the-content", notifier.getContent());
+    }
+
+    @Test
+    public void testGetRequiredMonitorService() {
+        assertSame(BuildStepMonitor.NONE, notifier.getRequiredMonitorService());
+    }
+
+    @Test
+    public void testPerformSuccessTraditionalBehavior() throws Exception {
+        notifier.setNotificationTags("unexpanded-tags");
+        when(envVars.expand("unexpanded-tags")).thenReturn("expanded-tags");
+
+        when(build.getResult()).thenReturn(Result.SUCCESS);
+
+        assertTrue(notifier.perform(build, launcher, listener));
+
+        ArgumentCaptor<TeamInboxMessage> captor = ArgumentCaptor.forClass(TeamInboxMessage.class);
+        verify(flowdockAPI).pushTeamInboxMessage(captor.capture());
+        assertSame(teamInboxMessage, captor.getValue());
+
+        verify(teamInboxMessage).setTags("expanded-tags");
+    }
+
+    @Test
+    public void testPerformSuccessWithContentAndSubject() throws Exception {
+        notifier.setContent("unexpanded-content");
+        notifier.setSubject("unexpanded-subject");
+
+        when(envVars.expand("unexpanded-content")).thenReturn("expanded-content");
+        when(envVars.expand("unexpanded-subject")).thenReturn("expanded-subject");
+
+        when(build.getResult()).thenReturn(Result.SUCCESS);
+
+        assertTrue(notifier.perform(build, launcher, listener));
+
+        ArgumentCaptor<TeamInboxMessage> captor = ArgumentCaptor.forClass(TeamInboxMessage.class);
+        verify(flowdockAPI).pushTeamInboxMessage(captor.capture());
+        assertSame(teamInboxMessage, captor.getValue());
+
+        verify(teamInboxMessage).setContent("expanded-content");
+        verify(teamInboxMessage).setSubject("expanded-subject");
+    }
+
+    @Test
+    public void testPerformFailure() throws Exception {
+        when(build.getResult()).thenReturn(Result.FAILURE);
+
+        assertTrue(notifier.perform(build, launcher, listener));
+
+        verify(flowdockAPI).pushTeamInboxMessage(any(TeamInboxMessage.class));
+        verify(flowdockAPI).pushChatMessage(any(ChatMessage.class));
+
+    }
+
+    @Test
+    public void testPerformFailureWithContent() throws Exception {
+        notifier.setContent("unexpanded-content");
+        notifier.setSubject("unexpanded-subject");
+
+        when(envVars.expand("unexpanded-content")).thenReturn("expanded-content");
+        when(envVars.expand("unexpanded-subject")).thenReturn("expanded-subject");
+
+        when(build.getResult()).thenReturn(Result.FAILURE);
+
+        assertTrue(notifier.perform(build, launcher, listener));
+
+        verify(flowdockAPI).pushTeamInboxMessage(any(TeamInboxMessage.class));
+        verify(flowdockAPI).pushChatMessage(any(ChatMessage.class));
+
+        verify(chatMessage).setContent("expanded-content");
+    }
+
 }

--- a/src/test/java/com/flowdock/jenkins/TeamInboxMessageTest.java
+++ b/src/test/java/com/flowdock/jenkins/TeamInboxMessageTest.java
@@ -39,184 +39,183 @@ import jenkins.model.Jenkins;
  */
 public class TeamInboxMessageTest {
 
-    private TeamInboxMessage message;
+	private TeamInboxMessage message;
+	
+	@Mock
+	private AbstractProject parent;
+	
+	@Mock
+	private AbstractBuild build;
 
-    @Mock
-    private AbstractProject parent;
+	private ChatMessage chatMessage;
+	
+	@Mock
+	private BuildListener buildListener;
 
-    @Mock
-    private AbstractBuild build;
+	@Mock
+	private AbstractProject project;
+	
+	@Mock
+	private Jenkins jenkins;
+	
+	@Mock
+	private EnvVars envVars;
 
-    private ChatMessage chatMessage;
+	@Mock
+	private SCM scm;
+	
+	@Mock
+	private ChangeLogSet<? extends Entry> changeLogSet;
+	
+	@Before
+	public void setup() throws Exception {
+		MockitoAnnotations.initMocks(this);
+		
+		message = new TeamInboxMessage();
+		message.setContent("message-content");
+		message.setFromAddress("jenkins@email.address");
+		message.setFromName("Jenkins Build");
+		message.setLink("http://localhost/thelink");
+		message.setProject("Project Foo");
+		message.setSource("the-source");
+		message.setSubject("Subject Line");
+		message.setTags("tag-a, tag-b");
+		
+		when(build.getProject()).thenReturn(project);
+		when(project.getRootProject()).thenReturn(project);
+		when(project.getDisplayName()).thenReturn("Project Name");
+		when(jenkins.getRootUrl()).thenReturn("http://localhost:8080");
+		when(build.getDisplayName()).thenReturn("Build Name");
+		when(build.getUrl()).thenReturn("/the-build-url");
+		when(build.getEnvironment(buildListener)).thenReturn(envVars);
+	}
+	
+	@Test
+	public void testAsPostData() throws UnsupportedEncodingException {
+		String postData = message.asPostData();
+		
+		assertEquals("subject=Subject+Line&content=message-content&from_address=jenkins%40email.address&from_name=Jenkins+Build&source=the-source&project=Project+Foo&link=http%3A%2F%2Flocalhost%2Fthelink&tags=tag-a%2Ctag-b",
+				postData);
+	}
 
-    @Mock
-    private BuildListener buildListener;
+	@Test
+	public void testFromBuildSuccessWithGit() throws Exception {
+		when(envVars.get("GIT_BRANCH")).thenReturn("master");
+		when(envVars.get("GIT_URL")).thenReturn("git://git.url");
+		
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		
+		TeamInboxMessage inboxMessage = message.fromBuild(jenkins, 
+				build, BuildResult.SUCCESS, buildListener);
+		
+		assertNotNull(inboxMessage);
+		assertEquals("subject=Project+Name+build+Build+Name+was+successful&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3ESUCCESS%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E%3Cbr+%2F%3E%3Cstrong%3EVersion+control%3A%3C%2Fstrong%3E%3Cbr+%2F%3EGit+branch%3A+master%3Cbr%2F%3EGit+URL%3A+git%3A%2F%2Fgit.url%3Cbr%2F%3E%3Cbr%2F%3E&from_address=build%2Bok%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
+				inboxMessage.asPostData());
+	}
 
-    @Mock
-    private AbstractProject project;
+	@Test
+	public void testFromBuildSuccess() throws Exception {
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		
+		TeamInboxMessage inboxMessage = message.fromBuild(jenkins, 
+				build, BuildResult.SUCCESS, buildListener);
+		
+		assertNotNull(inboxMessage);
+		assertEquals("subject=Project+Name+build+Build+Name+was+successful&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3ESUCCESS%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E&from_address=build%2Bok%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
+				inboxMessage.asPostData());
+	}
 
-    @Mock
-    private Jenkins jenkins;
+	@Test
+	public void testFromBuildSuccessWithChangeSets() throws Exception {
+		/*
+		 * TODO:  This whole behavior is pretty gnarly stuff.  The act of managing
+		 * changesets is terribly complicated and needs some refactoring.
+		 */
+		changeLogSet = setupChangeLogSet(build);
 
-    @Mock
-    private EnvVars envVars;
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		when(build.getChangeSet()).thenReturn(changeLogSet);
+		
+		TeamInboxMessage inboxMessage = message.fromBuild(jenkins, 
+				build, BuildResult.SUCCESS, buildListener);
+		
+		assertNotNull(inboxMessage);
+		assertEquals("subject=Project+Name+build+Build+Name+was+successful&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3ESUCCESS%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E%3Ch3%3EChanges%3C%2Fh3%3E%3Cdiv+class%3D%22commits%22%3E%3Cul+class%3D%22commit-list+clean%22%3E%3Cli+class%3D%22commit%22%3E%3Cspan+class%3D%22commit-details%22%3E%3Cspan+class%3D%22author-info%22%3E%3Cspan%3Enull%3C%2Fspan%3E%3C%2Fspan%3E+%26nbsp%3B%3Cspan+title%3D%22unknown%22+class%3D%22commit-sha%22%3Eunknown%3C%2Fspan%3E+%26nbsp%3B%3Cspan+class%3D%22commit-message%22%3Echange%3C%2Fspan%3E%3C%2Fspan%3E%3C%2Fli%3E%3C%2Ful%3E%3C%2Fdiv%3E&from_address=build%2Bok%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
+				inboxMessage.asPostData());
+	}
 
-    @Mock
-    private SCM scm;
+	private ChangeLogSet<? extends Entry> setupChangeLogSet(AbstractBuild build) {
+		Set<MyChangeLogEntry> changes = new HashSet<TeamInboxMessageTest.MyChangeLogEntry>();
+		changes.add(new MyChangeLogEntry("change", "path"));
+		
+		return new MyChangeLogSet(build, null, changes);
+	}
+	
+	private EntryImpl setupEntry(String author) {
+		EntryImpl entry = new EntryImpl().withAuthor(author);
+		return entry;
+	}
 
-    @Mock
-    private ChangeLogSet<? extends Entry> changeLogSet;
+	@Test
+	public void testFromBuildFailWithGit() throws Exception {
+		when(envVars.get("GIT_BRANCH")).thenReturn("master");
+		when(envVars.get("GIT_URL")).thenReturn("git://git.url");
+		
+		when(build.getResult()).thenReturn(Result.FAILURE);
+		
+		TeamInboxMessage inboxMessage = message.fromBuild(jenkins, 
+				build, BuildResult.FAILURE, buildListener);
+		
+		assertNotNull(inboxMessage);
+		assertEquals("subject=Project+Name+build+Build+Name+failed&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3EFAILURE%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E%3Cbr+%2F%3E%3Cstrong%3EVersion+control%3A%3C%2Fstrong%3E%3Cbr+%2F%3EGit+branch%3A+master%3Cbr%2F%3EGit+URL%3A+git%3A%2F%2Fgit.url%3Cbr%2F%3E%3Cbr%2F%3E&from_address=build%2Bfail%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
+				inboxMessage.asPostData());
+	}
+	
+	private static final class MyChangeLogSet extends ChangeLogSet<MyChangeLogEntry> {
 
-    @Before
-    public void setup() throws Exception {
-        MockitoAnnotations.initMocks(this);
+		private Set<MyChangeLogEntry> changes;
+		
+		public MyChangeLogSet(Run<?, ?> run, RepositoryBrowser<?> browser, Set<MyChangeLogEntry> changes) {
+			super(run, browser);
+			this.changes = changes;
+		}
 
-        message = new TeamInboxMessage();
-        message.setContent("message-content");
-        message.setFromAddress("jenkins@email.address");
-        message.setFromName("Jenkins Build");
-        message.setLink("http://localhost/thelink");
-        message.setProject("Project Foo");
-        message.setSource("the-source");
-        message.setSubject("Subject Line");
-        message.setTags("tag-a, tag-b");
+		@Override
+		public Iterator<MyChangeLogEntry> iterator() {
+			return changes.iterator();
+		}
 
-        when(build.getProject()).thenReturn(project);
-        when(project.getRootProject()).thenReturn(project);
-        when(project.getDisplayName()).thenReturn("Project Name");
-        when(jenkins.getRootUrl()).thenReturn("http://localhost:8080");
-        when(build.getDisplayName()).thenReturn("Build Name");
-        when(build.getUrl()).thenReturn("/the-build-url");
-        when(build.getEnvironment(buildListener)).thenReturn(envVars);
-    }
+		@Override
+		public boolean isEmptySet() {
+			return changes.isEmpty();
+		}
+		
+	}
+	
+	private static final class MyChangeLogEntry extends Entry {
 
-    @Test
-    public void testAsPostData() throws UnsupportedEncodingException {
-        String postData = message.asPostData();
+		private String message;
+		private String path;
+		
+		public MyChangeLogEntry(String message, String path) {
+			this.message = message;
+			this.path = path;
+		}
+		
+		@Override
+		public String getMsg() {
+			return message;
+		}
 
-        assertEquals(
-                "subject=Subject+Line&content=message-content&from_address=jenkins%40email.address&from_name=Jenkins+Build&source=the-source&project=Project+Foo&link=http%3A%2F%2Flocalhost%2Fthelink&tags=tag-a%2Ctag-b",
-                postData);
-    }
+		@Override
+		public User getAuthor() {
+			return null;
+		}
 
-    @Test
-    public void testFromBuildSuccessWithGit() throws Exception {
-        when(envVars.get("GIT_BRANCH")).thenReturn("master");
-        when(envVars.get("GIT_URL")).thenReturn("git://git.url");
-
-        when(build.getResult()).thenReturn(Result.SUCCESS);
-
-        TeamInboxMessage inboxMessage = message.fromBuild(jenkins, build, BuildResult.SUCCESS, buildListener);
-
-        assertNotNull(inboxMessage);
-        assertEquals(
-                "subject=Project+Name+build+Build+Name+was+successful&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3ESUCCESS%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E%3Cbr+%2F%3E%3Cstrong%3EVersion+control%3A%3C%2Fstrong%3E%3Cbr+%2F%3EGit+branch%3A+master%3Cbr%2F%3EGit+URL%3A+git%3A%2F%2Fgit.url%3Cbr%2F%3E%3Cbr%2F%3E&from_address=build%2Bok%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
-                inboxMessage.asPostData());
-    }
-
-    @Test
-    public void testFromBuildSuccess() throws Exception {
-        when(build.getResult()).thenReturn(Result.SUCCESS);
-
-        TeamInboxMessage inboxMessage = message.fromBuild(jenkins, build, BuildResult.SUCCESS, buildListener);
-
-        assertNotNull(inboxMessage);
-        assertEquals(
-                "subject=Project+Name+build+Build+Name+was+successful&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3ESUCCESS%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E&from_address=build%2Bok%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
-                inboxMessage.asPostData());
-    }
-
-    @Test
-    public void testFromBuildSuccessWithChangeSets() throws Exception {
-        /*
-         * TODO: This whole behavior is pretty gnarly stuff. The act of managing
-         * changesets is terribly complicated and needs some refactoring.
-         */
-        changeLogSet = setupChangeLogSet(build);
-
-        when(build.getResult()).thenReturn(Result.SUCCESS);
-        when(build.getChangeSet()).thenReturn(changeLogSet);
-
-        TeamInboxMessage inboxMessage = message.fromBuild(jenkins, build, BuildResult.SUCCESS, buildListener);
-
-        assertNotNull(inboxMessage);
-        assertEquals(
-                "subject=Project+Name+build+Build+Name+was+successful&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3ESUCCESS%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E%3Ch3%3EChanges%3C%2Fh3%3E%3Cdiv+class%3D%22commits%22%3E%3Cul+class%3D%22commit-list+clean%22%3E%3Cli+class%3D%22commit%22%3E%3Cspan+class%3D%22commit-details%22%3E%3Cspan+class%3D%22author-info%22%3E%3Cspan%3Enull%3C%2Fspan%3E%3C%2Fspan%3E+%26nbsp%3B%3Cspan+title%3D%22unknown%22+class%3D%22commit-sha%22%3Eunknown%3C%2Fspan%3E+%26nbsp%3B%3Cspan+class%3D%22commit-message%22%3Echange%3C%2Fspan%3E%3C%2Fspan%3E%3C%2Fli%3E%3C%2Ful%3E%3C%2Fdiv%3E&from_address=build%2Bok%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
-                inboxMessage.asPostData());
-    }
-
-    private ChangeLogSet<? extends Entry> setupChangeLogSet(AbstractBuild build) {
-        Set<MyChangeLogEntry> changes = new HashSet<TeamInboxMessageTest.MyChangeLogEntry>();
-        changes.add(new MyChangeLogEntry("change", "path"));
-
-        return new MyChangeLogSet(build, null, changes);
-    }
-
-    private EntryImpl setupEntry(String author) {
-        EntryImpl entry = new EntryImpl().withAuthor(author);
-        return entry;
-    }
-
-    @Test
-    public void testFromBuildFailWithGit() throws Exception {
-        when(envVars.get("GIT_BRANCH")).thenReturn("master");
-        when(envVars.get("GIT_URL")).thenReturn("git://git.url");
-
-        when(build.getResult()).thenReturn(Result.FAILURE);
-
-        TeamInboxMessage inboxMessage = message.fromBuild(jenkins, build, BuildResult.FAILURE, buildListener);
-
-        assertNotNull(inboxMessage);
-        assertEquals(
-                "subject=Project+Name+build+Build+Name+failed&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3EFAILURE%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E%3Cbr+%2F%3E%3Cstrong%3EVersion+control%3A%3C%2Fstrong%3E%3Cbr+%2F%3EGit+branch%3A+master%3Cbr%2F%3EGit+URL%3A+git%3A%2F%2Fgit.url%3Cbr%2F%3E%3Cbr%2F%3E&from_address=build%2Bfail%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
-                inboxMessage.asPostData());
-    }
-
-    private static final class MyChangeLogSet extends ChangeLogSet<MyChangeLogEntry> {
-
-        private Set<MyChangeLogEntry> changes;
-
-        public MyChangeLogSet(Run<?, ?> run, RepositoryBrowser<?> browser, Set<MyChangeLogEntry> changes) {
-            super(run, browser);
-            this.changes = changes;
-        }
-
-        @Override
-        public Iterator<MyChangeLogEntry> iterator() {
-            return changes.iterator();
-        }
-
-        @Override
-        public boolean isEmptySet() {
-            return changes.isEmpty();
-        }
-
-    }
-
-    private static final class MyChangeLogEntry extends Entry {
-
-        private String message;
-        private String path;
-
-        public MyChangeLogEntry(String message, String path) {
-            this.message = message;
-            this.path = path;
-        }
-
-        @Override
-        public String getMsg() {
-            return message;
-        }
-
-        @Override
-        public User getAuthor() {
-            return null;
-        }
-
-        @Override
-        public Collection<String> getAffectedPaths() {
-            return Arrays.asList(path);
-        }
-
-    }
+		@Override
+		public Collection<String> getAffectedPaths() {
+			return Arrays.asList(path);
+		}
+		
+	}
 }

--- a/src/test/java/com/flowdock/jenkins/TeamInboxMessageTest.java
+++ b/src/test/java/com/flowdock/jenkins/TeamInboxMessageTest.java
@@ -1,0 +1,221 @@
+package com.flowdock.jenkins;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.jvnet.hudson.test.FakeChangeLogSCM.EntryImpl;
+import org.jvnet.hudson.test.FakeChangeLogSCM.FakeChangeLogSet;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import hudson.EnvVars;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Job;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.User;
+import hudson.scm.ChangeLogSet;
+import hudson.scm.RepositoryBrowser;
+import hudson.scm.SCM;
+import hudson.scm.ChangeLogSet.Entry;
+import jenkins.model.Jenkins;
+
+/**
+ * Unit tests for {@link TeamInboxMessage}
+ * 
+ *
+ */
+public class TeamInboxMessageTest {
+
+	private TeamInboxMessage message;
+	
+	@Mock
+	private AbstractProject parent;
+	
+	@Mock
+	private AbstractBuild build;
+
+	private ChatMessage chatMessage;
+	
+	@Mock
+	private BuildListener buildListener;
+
+	@Mock
+	private AbstractProject project;
+	
+	@Mock
+	private Jenkins jenkins;
+	
+	@Mock
+	private EnvVars envVars;
+
+	@Mock
+	private SCM scm;
+	
+	@Mock
+	private ChangeLogSet<? extends Entry> changeLogSet;
+	
+	@Before
+	public void setup() throws Exception {
+		MockitoAnnotations.initMocks(this);
+		
+		message = new TeamInboxMessage();
+		message.setContent("message-content");
+		message.setFromAddress("jenkins@email.address");
+		message.setFromName("Jenkins Build");
+		message.setLink("http://localhost/thelink");
+		message.setProject("Project Foo");
+		message.setSource("the-source");
+		message.setSubject("Subject Line");
+		message.setTags("tag-a, tag-b");
+		
+		when(build.getProject()).thenReturn(project);
+		when(project.getRootProject()).thenReturn(project);
+		when(project.getDisplayName()).thenReturn("Project Name");
+		when(jenkins.getRootUrl()).thenReturn("http://localhost:8080");
+		when(build.getDisplayName()).thenReturn("Build Name");
+		when(build.getUrl()).thenReturn("/the-build-url");
+		when(build.getEnvironment(buildListener)).thenReturn(envVars);
+	}
+	
+	@Test
+	public void testAsPostData() throws UnsupportedEncodingException {
+		String postData = message.asPostData();
+		
+		assertEquals("subject=Subject+Line&content=message-content&from_address=jenkins%40email.address&from_name=Jenkins+Build&source=the-source&project=Project+Foo&link=http%3A%2F%2Flocalhost%2Fthelink&tags=tag-a%2Ctag-b",
+				postData);
+	}
+
+	@Test
+	public void testFromBuildSuccessWithGit() throws Exception {
+		when(envVars.get("GIT_BRANCH")).thenReturn("master");
+		when(envVars.get("GIT_URL")).thenReturn("git://git.url");
+		
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		
+		TeamInboxMessage inboxMessage = message.fromBuild(jenkins, 
+				build, BuildResult.SUCCESS, buildListener);
+		
+		assertNotNull(inboxMessage);
+		assertEquals("subject=Project+Name+build+Build+Name+was+successful&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3ESUCCESS%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E%3Cbr+%2F%3E%3Cstrong%3EVersion+control%3A%3C%2Fstrong%3E%3Cbr+%2F%3EGit+branch%3A+master%3Cbr%2F%3EGit+URL%3A+git%3A%2F%2Fgit.url%3Cbr%2F%3E%3Cbr%2F%3E&from_address=build%2Bok%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
+				inboxMessage.asPostData());
+	}
+
+	@Test
+	public void testFromBuildSuccess() throws Exception {
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		
+		TeamInboxMessage inboxMessage = message.fromBuild(jenkins, 
+				build, BuildResult.SUCCESS, buildListener);
+		
+		assertNotNull(inboxMessage);
+		assertEquals("subject=Project+Name+build+Build+Name+was+successful&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3ESUCCESS%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E&from_address=build%2Bok%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
+				inboxMessage.asPostData());
+	}
+
+	@Test
+	public void testFromBuildSuccessWithChangeSets() throws Exception {
+		/*
+		 * TODO:  This whole behavior is pretty gnarly stuff.  The act of managing
+		 * changesets is terribly complicated and needs some refactoring.
+		 */
+		changeLogSet = setupChangeLogSet(build);
+
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+		when(build.getChangeSet()).thenReturn(changeLogSet);
+		
+		TeamInboxMessage inboxMessage = message.fromBuild(jenkins, 
+				build, BuildResult.SUCCESS, buildListener);
+		
+		assertNotNull(inboxMessage);
+		assertEquals("subject=Project+Name+build+Build+Name+was+successful&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3ESUCCESS%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E%3Ch3%3EChanges%3C%2Fh3%3E%3Cdiv+class%3D%22commits%22%3E%3Cul+class%3D%22commit-list+clean%22%3E%3Cli+class%3D%22commit%22%3E%3Cspan+class%3D%22commit-details%22%3E%3Cspan+class%3D%22author-info%22%3E%3Cspan%3Enull%3C%2Fspan%3E%3C%2Fspan%3E+%26nbsp%3B%3Cspan+title%3D%22unknown%22+class%3D%22commit-sha%22%3Eunknown%3C%2Fspan%3E+%26nbsp%3B%3Cspan+class%3D%22commit-message%22%3Echange%3C%2Fspan%3E%3C%2Fspan%3E%3C%2Fli%3E%3C%2Ful%3E%3C%2Fdiv%3E&from_address=build%2Bok%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
+				inboxMessage.asPostData());
+	}
+
+	private ChangeLogSet<? extends Entry> setupChangeLogSet(AbstractBuild build) {
+		Set<MyChangeLogEntry> changes = new HashSet<TeamInboxMessageTest.MyChangeLogEntry>();
+		changes.add(new MyChangeLogEntry("change", "path"));
+		
+		return new MyChangeLogSet(build, null, changes);
+	}
+	
+	private EntryImpl setupEntry(String author) {
+		EntryImpl entry = new EntryImpl().withAuthor(author);
+		return entry;
+	}
+
+	@Test
+	public void testFromBuildFailWithGit() throws Exception {
+		when(envVars.get("GIT_BRANCH")).thenReturn("master");
+		when(envVars.get("GIT_URL")).thenReturn("git://git.url");
+		
+		when(build.getResult()).thenReturn(Result.FAILURE);
+		
+		TeamInboxMessage inboxMessage = message.fromBuild(jenkins, 
+				build, BuildResult.FAILURE, buildListener);
+		
+		assertNotNull(inboxMessage);
+		assertEquals("subject=Project+Name+build+Build+Name+failed&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3EFAILURE%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E%3Cbr+%2F%3E%3Cstrong%3EVersion+control%3A%3C%2Fstrong%3E%3Cbr+%2F%3EGit+branch%3A+master%3Cbr%2F%3EGit+URL%3A+git%3A%2F%2Fgit.url%3Cbr%2F%3E%3Cbr%2F%3E&from_address=build%2Bfail%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
+				inboxMessage.asPostData());
+	}
+	
+	private static final class MyChangeLogSet extends ChangeLogSet<MyChangeLogEntry> {
+
+		private Set<MyChangeLogEntry> changes;
+		
+		public MyChangeLogSet(Run<?, ?> run, RepositoryBrowser<?> browser, Set<MyChangeLogEntry> changes) {
+			super(run, browser);
+			this.changes = changes;
+		}
+
+		@Override
+		public Iterator<MyChangeLogEntry> iterator() {
+			return changes.iterator();
+		}
+
+		@Override
+		public boolean isEmptySet() {
+			return changes.isEmpty();
+		}
+		
+	}
+	
+	private static final class MyChangeLogEntry extends Entry {
+
+		private String message;
+		private String path;
+		
+		public MyChangeLogEntry(String message, String path) {
+			this.message = message;
+			this.path = path;
+		}
+		
+		@Override
+		public String getMsg() {
+			return message;
+		}
+
+		@Override
+		public User getAuthor() {
+			return null;
+		}
+
+		@Override
+		public Collection<String> getAffectedPaths() {
+			return Arrays.asList(path);
+		}
+		
+	}
+}

--- a/src/test/java/com/flowdock/jenkins/TeamInboxMessageTest.java
+++ b/src/test/java/com/flowdock/jenkins/TeamInboxMessageTest.java
@@ -39,183 +39,184 @@ import jenkins.model.Jenkins;
  */
 public class TeamInboxMessageTest {
 
-	private TeamInboxMessage message;
-	
-	@Mock
-	private AbstractProject parent;
-	
-	@Mock
-	private AbstractBuild build;
+    private TeamInboxMessage message;
 
-	private ChatMessage chatMessage;
-	
-	@Mock
-	private BuildListener buildListener;
+    @Mock
+    private AbstractProject parent;
 
-	@Mock
-	private AbstractProject project;
-	
-	@Mock
-	private Jenkins jenkins;
-	
-	@Mock
-	private EnvVars envVars;
+    @Mock
+    private AbstractBuild build;
 
-	@Mock
-	private SCM scm;
-	
-	@Mock
-	private ChangeLogSet<? extends Entry> changeLogSet;
-	
-	@Before
-	public void setup() throws Exception {
-		MockitoAnnotations.initMocks(this);
-		
-		message = new TeamInboxMessage();
-		message.setContent("message-content");
-		message.setFromAddress("jenkins@email.address");
-		message.setFromName("Jenkins Build");
-		message.setLink("http://localhost/thelink");
-		message.setProject("Project Foo");
-		message.setSource("the-source");
-		message.setSubject("Subject Line");
-		message.setTags("tag-a, tag-b");
-		
-		when(build.getProject()).thenReturn(project);
-		when(project.getRootProject()).thenReturn(project);
-		when(project.getDisplayName()).thenReturn("Project Name");
-		when(jenkins.getRootUrl()).thenReturn("http://localhost:8080");
-		when(build.getDisplayName()).thenReturn("Build Name");
-		when(build.getUrl()).thenReturn("/the-build-url");
-		when(build.getEnvironment(buildListener)).thenReturn(envVars);
-	}
-	
-	@Test
-	public void testAsPostData() throws UnsupportedEncodingException {
-		String postData = message.asPostData();
-		
-		assertEquals("subject=Subject+Line&content=message-content&from_address=jenkins%40email.address&from_name=Jenkins+Build&source=the-source&project=Project+Foo&link=http%3A%2F%2Flocalhost%2Fthelink&tags=tag-a%2Ctag-b",
-				postData);
-	}
+    private ChatMessage chatMessage;
 
-	@Test
-	public void testFromBuildSuccessWithGit() throws Exception {
-		when(envVars.get("GIT_BRANCH")).thenReturn("master");
-		when(envVars.get("GIT_URL")).thenReturn("git://git.url");
-		
-		when(build.getResult()).thenReturn(Result.SUCCESS);
-		
-		TeamInboxMessage inboxMessage = message.fromBuild(jenkins, 
-				build, BuildResult.SUCCESS, buildListener);
-		
-		assertNotNull(inboxMessage);
-		assertEquals("subject=Project+Name+build+Build+Name+was+successful&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3ESUCCESS%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E%3Cbr+%2F%3E%3Cstrong%3EVersion+control%3A%3C%2Fstrong%3E%3Cbr+%2F%3EGit+branch%3A+master%3Cbr%2F%3EGit+URL%3A+git%3A%2F%2Fgit.url%3Cbr%2F%3E%3Cbr%2F%3E&from_address=build%2Bok%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
-				inboxMessage.asPostData());
-	}
+    @Mock
+    private BuildListener buildListener;
 
-	@Test
-	public void testFromBuildSuccess() throws Exception {
-		when(build.getResult()).thenReturn(Result.SUCCESS);
-		
-		TeamInboxMessage inboxMessage = message.fromBuild(jenkins, 
-				build, BuildResult.SUCCESS, buildListener);
-		
-		assertNotNull(inboxMessage);
-		assertEquals("subject=Project+Name+build+Build+Name+was+successful&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3ESUCCESS%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E&from_address=build%2Bok%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
-				inboxMessage.asPostData());
-	}
+    @Mock
+    private AbstractProject project;
 
-	@Test
-	public void testFromBuildSuccessWithChangeSets() throws Exception {
-		/*
-		 * TODO:  This whole behavior is pretty gnarly stuff.  The act of managing
-		 * changesets is terribly complicated and needs some refactoring.
-		 */
-		changeLogSet = setupChangeLogSet(build);
+    @Mock
+    private Jenkins jenkins;
 
-		when(build.getResult()).thenReturn(Result.SUCCESS);
-		when(build.getChangeSet()).thenReturn(changeLogSet);
-		
-		TeamInboxMessage inboxMessage = message.fromBuild(jenkins, 
-				build, BuildResult.SUCCESS, buildListener);
-		
-		assertNotNull(inboxMessage);
-		assertEquals("subject=Project+Name+build+Build+Name+was+successful&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3ESUCCESS%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E%3Ch3%3EChanges%3C%2Fh3%3E%3Cdiv+class%3D%22commits%22%3E%3Cul+class%3D%22commit-list+clean%22%3E%3Cli+class%3D%22commit%22%3E%3Cspan+class%3D%22commit-details%22%3E%3Cspan+class%3D%22author-info%22%3E%3Cspan%3Enull%3C%2Fspan%3E%3C%2Fspan%3E+%26nbsp%3B%3Cspan+title%3D%22unknown%22+class%3D%22commit-sha%22%3Eunknown%3C%2Fspan%3E+%26nbsp%3B%3Cspan+class%3D%22commit-message%22%3Echange%3C%2Fspan%3E%3C%2Fspan%3E%3C%2Fli%3E%3C%2Ful%3E%3C%2Fdiv%3E&from_address=build%2Bok%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
-				inboxMessage.asPostData());
-	}
+    @Mock
+    private EnvVars envVars;
 
-	private ChangeLogSet<? extends Entry> setupChangeLogSet(AbstractBuild build) {
-		Set<MyChangeLogEntry> changes = new HashSet<TeamInboxMessageTest.MyChangeLogEntry>();
-		changes.add(new MyChangeLogEntry("change", "path"));
-		
-		return new MyChangeLogSet(build, null, changes);
-	}
-	
-	private EntryImpl setupEntry(String author) {
-		EntryImpl entry = new EntryImpl().withAuthor(author);
-		return entry;
-	}
+    @Mock
+    private SCM scm;
 
-	@Test
-	public void testFromBuildFailWithGit() throws Exception {
-		when(envVars.get("GIT_BRANCH")).thenReturn("master");
-		when(envVars.get("GIT_URL")).thenReturn("git://git.url");
-		
-		when(build.getResult()).thenReturn(Result.FAILURE);
-		
-		TeamInboxMessage inboxMessage = message.fromBuild(jenkins, 
-				build, BuildResult.FAILURE, buildListener);
-		
-		assertNotNull(inboxMessage);
-		assertEquals("subject=Project+Name+build+Build+Name+failed&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3EFAILURE%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E%3Cbr+%2F%3E%3Cstrong%3EVersion+control%3A%3C%2Fstrong%3E%3Cbr+%2F%3EGit+branch%3A+master%3Cbr%2F%3EGit+URL%3A+git%3A%2F%2Fgit.url%3Cbr%2F%3E%3Cbr%2F%3E&from_address=build%2Bfail%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
-				inboxMessage.asPostData());
-	}
-	
-	private static final class MyChangeLogSet extends ChangeLogSet<MyChangeLogEntry> {
+    @Mock
+    private ChangeLogSet<? extends Entry> changeLogSet;
 
-		private Set<MyChangeLogEntry> changes;
-		
-		public MyChangeLogSet(Run<?, ?> run, RepositoryBrowser<?> browser, Set<MyChangeLogEntry> changes) {
-			super(run, browser);
-			this.changes = changes;
-		}
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
 
-		@Override
-		public Iterator<MyChangeLogEntry> iterator() {
-			return changes.iterator();
-		}
+        message = new TeamInboxMessage();
+        message.setContent("message-content");
+        message.setFromAddress("jenkins@email.address");
+        message.setFromName("Jenkins Build");
+        message.setLink("http://localhost/thelink");
+        message.setProject("Project Foo");
+        message.setSource("the-source");
+        message.setSubject("Subject Line");
+        message.setTags("tag-a, tag-b");
 
-		@Override
-		public boolean isEmptySet() {
-			return changes.isEmpty();
-		}
-		
-	}
-	
-	private static final class MyChangeLogEntry extends Entry {
+        when(build.getProject()).thenReturn(project);
+        when(project.getRootProject()).thenReturn(project);
+        when(project.getDisplayName()).thenReturn("Project Name");
+        when(jenkins.getRootUrl()).thenReturn("http://localhost:8080");
+        when(build.getDisplayName()).thenReturn("Build Name");
+        when(build.getUrl()).thenReturn("/the-build-url");
+        when(build.getEnvironment(buildListener)).thenReturn(envVars);
+    }
 
-		private String message;
-		private String path;
-		
-		public MyChangeLogEntry(String message, String path) {
-			this.message = message;
-			this.path = path;
-		}
-		
-		@Override
-		public String getMsg() {
-			return message;
-		}
+    @Test
+    public void testAsPostData() throws UnsupportedEncodingException {
+        String postData = message.asPostData();
 
-		@Override
-		public User getAuthor() {
-			return null;
-		}
+        assertEquals(
+                "subject=Subject+Line&content=message-content&from_address=jenkins%40email.address&from_name=Jenkins+Build&source=the-source&project=Project+Foo&link=http%3A%2F%2Flocalhost%2Fthelink&tags=tag-a%2Ctag-b",
+                postData);
+    }
 
-		@Override
-		public Collection<String> getAffectedPaths() {
-			return Arrays.asList(path);
-		}
-		
-	}
+    @Test
+    public void testFromBuildSuccessWithGit() throws Exception {
+        when(envVars.get("GIT_BRANCH")).thenReturn("master");
+        when(envVars.get("GIT_URL")).thenReturn("git://git.url");
+
+        when(build.getResult()).thenReturn(Result.SUCCESS);
+
+        TeamInboxMessage inboxMessage = message.fromBuild(jenkins, build, BuildResult.SUCCESS, buildListener);
+
+        assertNotNull(inboxMessage);
+        assertEquals(
+                "subject=Project+Name+build+Build+Name+was+successful&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3ESUCCESS%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E%3Cbr+%2F%3E%3Cstrong%3EVersion+control%3A%3C%2Fstrong%3E%3Cbr+%2F%3EGit+branch%3A+master%3Cbr%2F%3EGit+URL%3A+git%3A%2F%2Fgit.url%3Cbr%2F%3E%3Cbr%2F%3E&from_address=build%2Bok%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
+                inboxMessage.asPostData());
+    }
+
+    @Test
+    public void testFromBuildSuccess() throws Exception {
+        when(build.getResult()).thenReturn(Result.SUCCESS);
+
+        TeamInboxMessage inboxMessage = message.fromBuild(jenkins, build, BuildResult.SUCCESS, buildListener);
+
+        assertNotNull(inboxMessage);
+        assertEquals(
+                "subject=Project+Name+build+Build+Name+was+successful&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3ESUCCESS%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E&from_address=build%2Bok%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
+                inboxMessage.asPostData());
+    }
+
+    @Test
+    public void testFromBuildSuccessWithChangeSets() throws Exception {
+        /*
+         * TODO: This whole behavior is pretty gnarly stuff. The act of managing
+         * changesets is terribly complicated and needs some refactoring.
+         */
+        changeLogSet = setupChangeLogSet(build);
+
+        when(build.getResult()).thenReturn(Result.SUCCESS);
+        when(build.getChangeSet()).thenReturn(changeLogSet);
+
+        TeamInboxMessage inboxMessage = message.fromBuild(jenkins, build, BuildResult.SUCCESS, buildListener);
+
+        assertNotNull(inboxMessage);
+        assertEquals(
+                "subject=Project+Name+build+Build+Name+was+successful&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3ESUCCESS%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E%3Ch3%3EChanges%3C%2Fh3%3E%3Cdiv+class%3D%22commits%22%3E%3Cul+class%3D%22commit-list+clean%22%3E%3Cli+class%3D%22commit%22%3E%3Cspan+class%3D%22commit-details%22%3E%3Cspan+class%3D%22author-info%22%3E%3Cspan%3Enull%3C%2Fspan%3E%3C%2Fspan%3E+%26nbsp%3B%3Cspan+title%3D%22unknown%22+class%3D%22commit-sha%22%3Eunknown%3C%2Fspan%3E+%26nbsp%3B%3Cspan+class%3D%22commit-message%22%3Echange%3C%2Fspan%3E%3C%2Fspan%3E%3C%2Fli%3E%3C%2Ful%3E%3C%2Fdiv%3E&from_address=build%2Bok%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
+                inboxMessage.asPostData());
+    }
+
+    private ChangeLogSet<? extends Entry> setupChangeLogSet(AbstractBuild build) {
+        Set<MyChangeLogEntry> changes = new HashSet<TeamInboxMessageTest.MyChangeLogEntry>();
+        changes.add(new MyChangeLogEntry("change", "path"));
+
+        return new MyChangeLogSet(build, null, changes);
+    }
+
+    private EntryImpl setupEntry(String author) {
+        EntryImpl entry = new EntryImpl().withAuthor(author);
+        return entry;
+    }
+
+    @Test
+    public void testFromBuildFailWithGit() throws Exception {
+        when(envVars.get("GIT_BRANCH")).thenReturn("master");
+        when(envVars.get("GIT_URL")).thenReturn("git://git.url");
+
+        when(build.getResult()).thenReturn(Result.FAILURE);
+
+        TeamInboxMessage inboxMessage = message.fromBuild(jenkins, build, BuildResult.FAILURE, buildListener);
+
+        assertNotNull(inboxMessage);
+        assertEquals(
+                "subject=Project+Name+build+Build+Name+failed&content=%3Ch3%3EProject+Name%3C%2Fh3%3EBuild%3A+Build+Name%3Cbr+%2F%3EResult%3A+%3Cstrong%3EFAILURE%3C%2Fstrong%3E%3Cbr+%2F%3EURL%3A+%3Ca+href%3D%22http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url%22%3Enull%3C%2Fa%3E%3Cbr+%2F%3E%3Cbr+%2F%3E%3Cstrong%3EVersion+control%3A%3C%2Fstrong%3E%3Cbr+%2F%3EGit+branch%3A+master%3Cbr%2F%3EGit+URL%3A+git%3A%2F%2Fgit.url%3Cbr%2F%3E%3Cbr%2F%3E&from_address=build%2Bfail%40flowdock.com&from_name=CI&source=Jenkins&project=Project+Name&link=http%3A%2F%2Flocalhost%3A8080%2Fthe-build-url&tags=",
+                inboxMessage.asPostData());
+    }
+
+    private static final class MyChangeLogSet extends ChangeLogSet<MyChangeLogEntry> {
+
+        private Set<MyChangeLogEntry> changes;
+
+        public MyChangeLogSet(Run<?, ?> run, RepositoryBrowser<?> browser, Set<MyChangeLogEntry> changes) {
+            super(run, browser);
+            this.changes = changes;
+        }
+
+        @Override
+        public Iterator<MyChangeLogEntry> iterator() {
+            return changes.iterator();
+        }
+
+        @Override
+        public boolean isEmptySet() {
+            return changes.isEmpty();
+        }
+
+    }
+
+    private static final class MyChangeLogEntry extends Entry {
+
+        private String message;
+        private String path;
+
+        public MyChangeLogEntry(String message, String path) {
+            this.message = message;
+            this.path = path;
+        }
+
+        @Override
+        public String getMsg() {
+            return message;
+        }
+
+        @Override
+        public User getAuthor() {
+            return null;
+        }
+
+        @Override
+        public Collection<String> getAffectedPaths() {
+            return Arrays.asList(path);
+        }
+
+    }
 }


### PR DESCRIPTION
I've added configurable content and subject options for Flowdock chat & team inbox messages.  I've also tidied up the DataBoundConstructor with DataBoundSetters to better reflect the optional parameters.  This in turn makes the generate job DSL a bit cleaner.  Here's an example usage:

```
                    flowdockNotifier {
                        flowToken(devOpsFlowToken)
                        notificationTags("docker-dashboard, ${JOB_NAME}")
                        subject("[${k}] Deployment for ${project.projectName} of \$VERSION")
                        content("[${k}] Deployment for ${project.projectName} of \$VERSION by \$BUILD_USER_EMAIL run from ${v.deployServer}")
                    }
```
